### PR TITLE
[issue-58] - Created typings for the different Card Explorer Cards

### DIFF
--- a/app/imports/typings/radgrad.d.ts
+++ b/app/imports/typings/radgrad.d.ts
@@ -1,5 +1,4 @@
 /* eslint-disable */
-import { ProcessedSchema } from '../api/verification/VerificationRequestCollection';
 
 declare global {
   namespace Assets {
@@ -137,6 +136,69 @@ export interface IPagination {
     showCount: number;
   };
 }
+
+// Card Explorer Cards. Note that this does not refer to specifically ExplorerCard.tsx. But rather all the Cards that are
+// used to implement the Card Explorer Widgets (PlanCard, ProfileCard, TermCard, ExplorerCard, and StudentUserCard).
+export interface ICardExplorerCards {
+  item: {
+    _id: string;
+  };
+}
+
+export interface IPlanCard extends ICardExplorerCards {
+  type: string;
+  canAdd: boolean;
+  match: {
+    isExact: boolean;
+    path: string;
+    url: string;
+    params: {
+      username: string;
+    }
+  };
+}
+
+export interface IProfileCard extends ICardExplorerCards {
+  type: string;
+  canAdd: boolean;
+  match: {
+    isExact: boolean;
+    path: string;
+    url: string;
+    params: {
+      username: string;
+    }
+  };
+}
+
+export interface ITermCard extends ICardExplorerCards {
+  type: string;
+  canAdd: boolean;
+  match: {
+    isExact: boolean;
+    path: string;
+    url: string;
+    params: {
+      username: string;
+    }
+  };
+}
+
+export interface IExplorerCard extends ICardExplorerCards {
+  type: string;
+  match: {
+    isExact: boolean;
+    path: string;
+    url: string;
+    params: {
+      username: string;
+    }
+  };
+}
+
+export interface IStudentUserCard extends ICardExplorerCards {
+}
+
 
 export interface IDescriptionPair {
   label: string;
@@ -672,9 +734,11 @@ export interface IProfile {
 }
 
 // Advisor and Faculty Profiles
-export interface IAdvisorProfile extends IProfile {}
+export interface IAdvisorProfile extends IProfile {
+}
 
-export interface IFacultyProfile extends IProfile {}
+export interface IFacultyProfile extends IProfile {
+}
 
 export interface IProfileDefine extends IDumpOne {
   username: string;
@@ -729,6 +793,7 @@ export interface IMentorProfile extends IProfile {
   linkedin?: string;
   motivation: string;
 }
+
 export interface IMentorProfileDefine extends IProfileDefine {
   company: string;
   career: string;

--- a/app/imports/ui/components/shared/CardExplorerWidget.tsx
+++ b/app/imports/ui/components/shared/CardExplorerWidget.tsx
@@ -596,7 +596,7 @@ class CardExplorerWidget extends React.Component<ICardExplorerWidgetProps> {
               <Card.Group stackable={true} itemsPerRow={3} style={userStackableCardsStyle}>
                 {
                   // TODO
-                  // Array.from(advisorRoleUsers).map((user, index) => <StudentUserCard key={index} user={user}/>)
+                  // Array.from(advisorRoleUsers).map((user, index) => <StudentUserCard key={index} item={user}/>)
                 }
               </Card.Group>
             </Grid>
@@ -610,7 +610,7 @@ class CardExplorerWidget extends React.Component<ICardExplorerWidgetProps> {
               <Card.Group stackable={true} itemsPerRow={3} style={userStackableCardsStyle}>
                 {
                   // TODO
-                  // Array.from(advisorRoleUsers).map((user, index) => <StudentUserCard key={index} user={user}/>)
+                  // Array.from(advisorRoleUsers).map((user, index) => <StudentUserCard key={index} item={user}/>)
                 }
               </Card.Group>
             </Grid>
@@ -624,7 +624,7 @@ class CardExplorerWidget extends React.Component<ICardExplorerWidgetProps> {
               <Card.Group stackable={true} itemsPerRow={3} style={userStackableCardsStyle}>
                 {
                   // TODO
-                  // Array.from(advisorRoleUsers).map((user, index) => <StudentUserCard key={index} user={user}/>)
+                  // Array.from(advisorRoleUsers).map((user, index) => <StudentUserCard key={index} item={user}/>)
                 }
               </Card.Group>
             </Grid>
@@ -638,7 +638,7 @@ class CardExplorerWidget extends React.Component<ICardExplorerWidgetProps> {
               <Card.Group stackable={true} itemsPerRow={3} style={userStackableCardsStyle}>
                 {
                   // TODO
-                  // Array.from(advisorRoleUsers).map((user, index) => <StudentUserCard key={index} user={user}/>)
+                  // Array.from(advisorRoleUsers).map((user, index) => <StudentUserCard key={index} item={user}/>)
                 }
               </Card.Group>
             </Grid>

--- a/app/imports/ui/components/shared/CardExplorerWidget.tsx
+++ b/app/imports/ui/components/shared/CardExplorerWidget.tsx
@@ -237,6 +237,8 @@ class CardExplorerWidget extends React.Component<ICardExplorerWidgetProps> {
 
   // Used in both Courses and Opportunities Card Explorer
   private hiddenExists() {
+    if (!this.isRoleStudent()) return false;
+
     const username = this.getUsername();
     if (username) {
       const profile = Users.getProfile(username);
@@ -281,7 +283,6 @@ class CardExplorerWidget extends React.Component<ICardExplorerWidgetProps> {
         return _.filter(plans, p => profile.academicPlanID !== p._id);
       }
     }
-    console.log(plans);
     return plans;
   }
 

--- a/app/imports/ui/components/shared/ExplorerCard.tsx
+++ b/app/imports/ui/components/shared/ExplorerCard.tsx
@@ -3,23 +3,9 @@ import { Button, Card, Icon } from 'semantic-ui-react';
 import * as Markdown from 'react-markdown';
 import { Link } from 'react-router-dom';
 import { Slugs } from '../../../api/slug/SlugCollection';
+import { IExplorerCard } from '../../../typings/radgrad'; // eslint-disable-line
 
-interface IExplorerCardProps {
-  item: {
-    _id: string;
-  };
-  type: string;
-  match: {
-    isExact: boolean;
-    path: string;
-    url: string;
-    params: {
-      username: string;
-    }
-  };
-}
-
-class ExplorerCard extends React.Component<IExplorerCardProps> {
+class ExplorerCard extends React.Component<IExplorerCard> {
   constructor(props) {
     super(props);
   }


### PR DESCRIPTION
[ ] test passed
[ ] test-app passed

#58 
* Created typings for the different Card Explorer Cards (IProfileCard, IPlanCard, ITermCard, IExplorerCard, and IStudentUserCard)
* Fixed a minor bug where we didn't check if the role is a student in the hiddenExists() function. 

**What this accomplishes**
Right now pretty much all of the Cards are passed an item object. But only some cards are passed a type string, canAdd boolean, and a match object. Rather than having to copy paste each of these  types for each card, this PR created interfaces that can be simply imported to their corresponding cards.

**What contributors need to know**
You simply need to import the interface that corresponds to your card. For example, if you are implementing the Explorer card...
```
import { IExplorerCard} from '../../../typings/radgrad'; // eslint-disable-line

class ExplorerCard extends React.Component<IExplorerCard> {
  ....
}
```

If you need to add more props to the interface, simply create a new interface that extends from imported interface, add those new props, and use that interface in your class. The new interface should be conventionally named `I{OriginalName}Props` where OriginalName is the name of the imported interface.

```
import { IExplorerCard} from '../../../typings/radgrad'; // eslint-disable-line

interface IExplorerCardProps {
   ... new props ...
}

class ExplorerCard extends React.Component<IExplorerCardProps> {
  ....
}
```

Note that you must put the comment `// eslint-disable-line` on the import line. Otherwise it will give you an ESLint error saying that your imported interface is an unused var. This is because we are using the interface as a type rather than a var and currently the parser does not know that.