### PR TITLE
[issue-63] - Explorer Menu

### DIFF
--- a/app/imports/ui/components/shared/ExplorerMenu.tsx
+++ b/app/imports/ui/components/shared/ExplorerMenu.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { Dropdown, Menu, Header, Responsive } from 'semantic-ui-react';
-import { NavLink, withRouter } from 'react-router-dom';
+import { Dropdown, Menu, Header, Responsive, Button, Icon } from 'semantic-ui-react';
+import { NavLink, withRouter, Link } from 'react-router-dom';
 import * as _ from 'lodash';
 import {
   IAcademicPlan, //eslint-disable-line
@@ -17,9 +17,9 @@ import { Slugs } from '../../../api/slug/SlugCollection';
 
 type explorerInterfaces = IAcademicPlan | ICareerGoal | ICourse | IDesiredDegree | IInterest | IOpportunity;
 
-interface ICardExplorerMenuProps {
+interface IExplorerMenuProps {
   menuAddedList: { item: explorerInterfaces, count: number }[];
-  menuCareerList: { item: IInterest, count: number }[] | undefined;
+  menuCareerList?: { item: IInterest, count: number }[] | undefined;
   type: 'plans' | 'career-goals' | 'courses' | 'degrees' | 'interests' | 'opportunities' | 'users';
   role: 'student' | 'faculty' | 'mentor';
   match: {
@@ -32,7 +32,7 @@ interface ICardExplorerMenuProps {
   };
 }
 
-class CardExplorerMenu extends React.Component<ICardExplorerMenuProps> {
+class ExplorerMenu extends React.Component<IExplorerMenuProps> {
   constructor(props) {
     super(props);
   }
@@ -199,6 +199,7 @@ class CardExplorerMenu extends React.Component<ICardExplorerMenuProps> {
       position: 'absolute',
       marginLeft: '-20px',
     };
+    const marginTopStyle = { marginTop: '5px' };
 
     const menuItems = [
       { key: 'Academic Plans', route: 'plans' },
@@ -239,6 +240,9 @@ class CardExplorerMenu extends React.Component<ICardExplorerMenuProps> {
           {
             this.isType('plans') ?
               <React.Fragment>
+                <Button as={Link} to={`${baseRoute}/explorer/${this.props.type}`} style={marginTopStyle}>
+                  <Icon name="chevron circle left"/><br/>Back to {this.getTypeName()}
+                </Button>
                 {
                   isStudent ?
                     <Menu vertical={true} text={true}>
@@ -262,6 +266,9 @@ class CardExplorerMenu extends React.Component<ICardExplorerMenuProps> {
           {
             this.isType('courses') ?
               <React.Fragment>
+                <Button as={Link} to={`${baseRoute}/explorer/${this.props.type}`} style={marginTopStyle}>
+                  <Icon name="chevron circle left"/><br/>Back to {this.getTypeName()}
+                </Button>
                 {
                   isStudent ?
                     <Menu vertical={true} text={true}>
@@ -286,6 +293,9 @@ class CardExplorerMenu extends React.Component<ICardExplorerMenuProps> {
             this.isType('opportunities') ?
               <React.Fragment>
                 <a href={`mailto:${adminEmail}?subject=New Opportunity Suggestion`}>Suggest a new Opportunity</a>
+                <Button as={Link} to={`${baseRoute}/explorer/${this.props.type}`} style={marginTopStyle}>
+                  <Icon name="chevron circle left"/><br/>Back to {this.getTypeName()}
+                </Button>
                 {
                   isStudent ?
                     <Menu vertical={true} text={true}>
@@ -312,6 +322,9 @@ class CardExplorerMenu extends React.Component<ICardExplorerMenuProps> {
             this.isType('interests') ?
               <Menu vertical={true} text={true}>
                 <a href={`mailto:${adminEmail}?subject=New Interest Suggestion`}>Suggest a new Interest</a>
+                <Button as={Link} to={`${baseRoute}/explorer/${this.props.type}`} style={marginTopStyle}>
+                  <Icon name="chevron circle left"/><br/>Back to {this.getTypeName()}
+                </Button>
                 <Header as="h4" dividing={true}>MY INTERESTS</Header>
                 {
                   menuAddedList.map((listItem, index) => (
@@ -341,6 +354,9 @@ class CardExplorerMenu extends React.Component<ICardExplorerMenuProps> {
             this.isType('career-goals') ?
               <Menu vertical={true} text={true}>
                 <a href={`mailto:${adminEmail}?subject=New Career Goal Suggestion`}>Suggest a new Career Goal</a>
+                <Button as={Link} to={`${baseRoute}/explorer/${this.props.type}`} style={marginTopStyle}>
+                  <Icon name="chevron circle left"/><br/>Back to {this.getTypeName()}
+                </Button>
                 <Header as="h4" dividing={true}>MY CAREER GOALS</Header>
                 {
                   menuAddedList.map((listItem, index) => (
@@ -352,6 +368,14 @@ class CardExplorerMenu extends React.Component<ICardExplorerMenuProps> {
                   ))
                 }
               </Menu>
+              : ''
+          }
+
+          {
+            this.isType('degrees') ?
+              <Button as={Link} to={`${baseRoute}/explorer/${this.props.type}`} style={marginTopStyle}>
+                <Icon name="chevron circle left"/><br/>Back to {this.getTypeName()}
+              </Button>
               : ''
           }
         </Responsive>
@@ -513,4 +537,4 @@ class CardExplorerMenu extends React.Component<ICardExplorerMenuProps> {
   }
 }
 
-export default withRouter(CardExplorerMenu);
+export default withRouter(ExplorerMenu);

--- a/app/imports/ui/pages/shared/CardExplorerPage.tsx
+++ b/app/imports/ui/pages/shared/CardExplorerPage.tsx
@@ -119,6 +119,8 @@ class CardExplorerPage extends React.Component<ICardExplorerPageProps> {
     }
   }
 
+  // This function and the nonAdded functions in the switch statements are NOT used at all. However, I'm keeping them here
+  // just in case. -Gian
   private getNonAddedList = (): (IAcademicPlan | ICareerGoal | ICourse | IDesiredDegree | IInterest | IOpportunity)[] => {
     const type = this.getType();
     switch (type) {
@@ -326,10 +328,6 @@ class CardExplorerPage extends React.Component<ICardExplorerPageProps> {
     const helpMessage = HelpMessages.findOne({ routeName: this.props.match.path });
 
     const addedList = this.getAddedList();
-    // Decided not to implement rendering nonAddedList for now. In radgrad1, the nonAddedList only renders for mobile.
-    // I figured there's no point in implementing it then if it's only for mobile. I'll keep the functions to get nonAddedList
-    // in file just in case.
-    const nonAddedList = this.getNonAddedList();
     const isTypeInterest = this.getType() === 'interests'; // Only Interests takes in Career List for CardExplorerMenu
     type types = 'plans' | 'career-goals' | 'courses' | 'degrees' | 'interests' | 'opportunities' | 'users';
     type roles = 'student' | 'faculty' | 'mentor';
@@ -344,9 +342,10 @@ class CardExplorerPage extends React.Component<ICardExplorerPageProps> {
           </Grid.Row>
 
           <Grid.Column width={3}>
-            <CardExplorerMenu menuAddedList={addedList} menuNonAddedList={nonAddedList}
+            <CardExplorerMenu menuAddedList={addedList} type={this.getType() as types}
+                              role={this.getRoleByUrl()}
                               menuCareerList={isTypeInterest ? this.addedCareerInterests() : undefined}
-                              type={this.getType() as types} role={this.getRoleByUrl() as roles}/>
+            />
           </Grid.Column>
 
           <Grid.Column width={13}>

--- a/app/imports/ui/pages/shared/ExplorerDegreesPage.tsx
+++ b/app/imports/ui/pages/shared/ExplorerDegreesPage.tsx
@@ -13,6 +13,10 @@ import ExplorerDegreesWidget from '../../components/shared/ExplorerDegreesWidget
 import StudentPageMenuWidget from '../../components/student/StudentPageMenuWidget';
 import MentorPageMenuWidget from '../../components/mentor/MentorPageMenuWidget';
 import FacultyPageMenuWidget from '../../components/faculty/FacultyPageMenuWidget';
+import HelpPanelWidget from '../../components/shared/HelpPanelWidget';
+import ExplorerMenu from '../../components/shared/ExplorerMenu';
+import { HelpMessages } from '../../../api/help/HelpMessageCollection';
+import { IDesiredDegree } from '../../../typings/radgrad'; // eslint-disable-line
 
 interface IExplorerDegreesPageProps {
   match: {
@@ -52,6 +56,13 @@ class ExplorerDegreesPage extends React.Component<IExplorerDegreesPageProps> {
     }
   }
 
+  /* ####################################### EXPLORER MENU HELPER FUNCTIONS ######################################### */
+  private addedDegrees = (): { item: IDesiredDegree, count: number }[] => _.map(DesiredDegrees.findNonRetired({}, { sort: { name: 1 } }), (d) => ({
+    item: d,
+    count: 1,
+  }))
+
+  /* ####################################### EXPLORER DEGREES WIDGET HELPER FUNCTIONS ############################### */
   private degree = () => {
     const degreeSlugName = this.props.match.params.degree;
     const slug = Slugs.find({ name: degreeSlugName }).fetch();
@@ -86,6 +97,10 @@ class ExplorerDegreesPage extends React.Component<IExplorerDegreesPageProps> {
   private numUsers = (degree) => this.interestedUsers(degree).length;
 
   public render(): React.ReactElement<any> | string | number | {} | React.ReactNodeArray | React.ReactPortal | boolean | null | undefined {
+    const helpMessage = HelpMessages.findOne({ routeName: this.props.match.path });
+
+    const addedList = this.addedDegrees();
+
     const degree = this.degree();
     const name = degree.name;
     const slug = this.slugName(degree.slugID);
@@ -95,19 +110,21 @@ class ExplorerDegreesPage extends React.Component<IExplorerDegreesPageProps> {
 
     return (
       <React.Fragment>
-        {
-          this.renderPageMenuWidget()
-        }
+        {this.renderPageMenuWidget()}
 
         <Grid container={true} stackable={true}>
-          <Grid.Row width={3}>
-            {/*  TODO: Card Explorer Menu */}
+          <Grid.Row>
+            {helpMessage ? <HelpPanelWidget/> : ''}
           </Grid.Row>
 
-          <Grid.Row width={13}>
+          <Grid.Column width={3}>
+            <ExplorerMenu menuAddedList={addedList} type={'degrees'} role={this.getRoleByUrl()}/>
+          </Grid.Column>
+
+          <Grid.Column width={13}>
             <ExplorerDegreesWidget name={name} slug={slug} descriptionPairs={descriptionPairs} socialPairs={socialPairs}
                                    id={id} item={degree}/>
-          </Grid.Row>
+          </Grid.Column>
         </Grid>
       </React.Fragment>
     );


### PR DESCRIPTION
Status: 🚧 
* *meteor npm run test* ❌ 
* *meteor npm run test-app* ❌ 

**What this accomplishes**
Implemented the Explorer Menu part of #63, Closes #63 

**What contributors need to know**
Because only the CARD Explorer Page was made generic as of this PR, each of the Individual Explorer Pages (ExplorerCoursesPage, ExplorerDegreesPage, etc...), must implement the Explorer Menu for each of the page along with the function(s) needed to build the Explorer Menu. However, I don't think you guys need to worry about this too much. I think I'll complete #69 first and then I'll do these myself.