### PR TITLE
[issue-69] - Generic Individual Explorer Page

### DIFF
--- a/app/.meteor/versions
+++ b/app/.meteor/versions
@@ -1,7 +1,6 @@
 accounts-base@1.4.4
 accounts-password@1.5.1
 alanning:roles@1.2.16
-aldeed:browser-tests@0.1.1
 aldeed:collection2-core@2.1.2
 allow-deny@1.1.0
 atoy40:accounts-cas@0.0.2
@@ -28,7 +27,6 @@ ddp-server@2.3.0
 deps@1.0.12
 didericis:callpromise-mixin@0.0.1
 diff-sequence@1.1.1
-dispatch:mocha@0.4.1
 dynamic-import@0.5.1
 ecmascript@0.12.7
 ecmascript-runtime@0.7.0
@@ -75,7 +73,6 @@ npm-mongo@3.1.2
 observe-sequence@1.0.16
 ordered-dict@1.1.0
 percolate:synced-cron@1.3.2
-practicalmeteor:mocha-core@1.0.1
 promise@0.11.2
 raix:eventemitter@0.1.3
 random@1.1.0

--- a/app/imports/startup/client/routes-config.ts
+++ b/app/imports/startup/client/routes-config.ts
@@ -69,12 +69,7 @@ import AdminDataModelVerificationRequestsPage from '../../ui/pages/admin/AdminDa
 /* Explorers */
 import ExplorerHomePageContainer from '../../ui/pages/shared/ExplorerHomePage';
 import CardExplorerPageContainer from '../../ui/pages/shared/CardExplorerPage';
-import ExplorerCareerGoalsPageContainer from '../../ui/pages/shared/ExplorerCareerGoalsPage';
-import ExplorerDegreesPageContainer from '../../ui/pages/shared/ExplorerDegreesPage';
-import ExplorerCoursesPageContainer from '../../ui/pages/shared/ExplorerCoursesPage';
-import ExplorerInterestsPageContainer from '../../ui/pages/shared/ExplorerInterestsPage';
-import ExplorerOpportunitiesPageContainer from '../../ui/pages/shared/ExplorerOpportunitiesPage';
-import ExplorerPlansPageContainer from '../../ui/pages/shared/ExplorerPlansPage';
+import IndividualExplorerPageContainer from '../../ui/pages/shared/IndividualExplorerPage';
 
 export const routes = {
   ADMIN: [
@@ -286,11 +281,6 @@ export const routes = {
       component: ExplorerHomePageContainer,
     },
     {
-      path: '/faculty/:username/explorer/degrees',
-      exact: true,
-      component: CardExplorerPageContainer,
-    },
-    {
       path: '/faculty/:username/explorer/plans',
       exact: true,
       component: CardExplorerPageContainer,
@@ -298,7 +288,7 @@ export const routes = {
     {
       path: '/faculty/:username/explorer/plans/:plan',
       exact: true,
-      component: ExplorerPlansPageContainer,
+      component: IndividualExplorerPageContainer,
     },
     {
       path: '/faculty/:username/explorer/career-goals',
@@ -308,7 +298,7 @@ export const routes = {
     {
       path: '/faculty/:username/explorer/career-goals/:careergoal',
       exact: true,
-      component: ExplorerCareerGoalsPageContainer,
+      component: IndividualExplorerPageContainer,
     },
     {
       path: '/faculty/:username/explorer/courses',
@@ -318,7 +308,7 @@ export const routes = {
     {
       path: '/faculty/:username/explorer/courses/:course',
       exact: true,
-      component: ExplorerCoursesPageContainer,
+      component: IndividualExplorerPageContainer,
     },
     {
       path: '/faculty/:username/explorer/degrees',
@@ -328,7 +318,7 @@ export const routes = {
     {
       path: '/faculty/:username/explorer/degrees/:degree',
       exact: true,
-      component: ExplorerDegreesPageContainer,
+      component: IndividualExplorerPageContainer,
     },
     {
       path: '/faculty/:username/explorer/interests',
@@ -338,7 +328,7 @@ export const routes = {
     {
       path: '/faculty/:username/explorer/interests/:interest',
       exact: true,
-      component: ExplorerInterestsPageContainer,
+      component: IndividualExplorerPageContainer,
     },
     {
       path: '/faculty/:username/explorer/opportunities',
@@ -348,7 +338,7 @@ export const routes = {
     {
       path: '/faculty/:username/explorer/opportunities/:opportunity',
       exact: true,
-      component: ExplorerOpportunitiesPageContainer,
+      component: IndividualExplorerPageContainer,
     },
     {
       path: '/faculty/:username/explorer/users',
@@ -463,17 +453,6 @@ export const routes = {
       component: ExplorerHomePageContainer,
     },
     {
-      path: '/mentor/:username/explorer/interests',
-      exact: true,
-      component: CardExplorerPageContainer,
-    },
-    {
-
-      path: '/mentor/:username/explorer/interests/:interest',
-      exact: true,
-      component: ExplorerInterestsPageContainer,
-    },
-    {
       path: '/mentor/:username/explorer/plans',
       exact: true,
       component: CardExplorerPageContainer,
@@ -481,7 +460,7 @@ export const routes = {
     {
       path: '/mentor/:username/explorer/plans/:plan',
       exact: true,
-      component: ExplorerPlansPageContainer,
+      component: IndividualExplorerPageContainer,
     },
     {
       path: '/mentor/:username/explorer/career-goals',
@@ -491,7 +470,7 @@ export const routes = {
     {
       path: '/mentor/:username/explorer/career-goals/:careergoal',
       exact: true,
-      component: ExplorerCareerGoalsPageContainer,
+      component: IndividualExplorerPageContainer,
     },
     {
       path: '/mentor/:username/explorer/courses',
@@ -501,7 +480,7 @@ export const routes = {
     {
       path: '/mentor/:username/explorer/courses/:course',
       exact: true,
-      component: ExplorerCoursesPageContainer,
+      component: IndividualExplorerPageContainer,
     },
     {
       path: '/mentor/:username/explorer/degrees',
@@ -511,12 +490,18 @@ export const routes = {
     {
       path: '/mentor/:username/explorer/degrees/:degree',
       exact: true,
-      component: ExplorerDegreesPageContainer,
+      component: IndividualExplorerPageContainer,
     },
     {
       path: '/mentor/:username/explorer/interests',
       exact: true,
       component: CardExplorerPageContainer,
+    },
+    {
+
+      path: '/mentor/:username/explorer/interests/:interest',
+      exact: true,
+      component: IndividualExplorerPageContainer,
     },
     {
       path: '/mentor/:username/explorer/opportunities',
@@ -526,7 +511,7 @@ export const routes = {
     {
       path: '/mentor/:username/explorer/opportunities/:opportunity',
       exact: true,
-      component: ExplorerOpportunitiesPageContainer,
+      component: IndividualExplorerPageContainer,
     },
     {
       path: '/mentor/:username/explorer/users',
@@ -560,7 +545,7 @@ export const routes = {
     {
       path: '/student/:username/explorer/plans/:plan',
       exact: true,
-      component: ExplorerPlansPageContainer,
+      component: IndividualExplorerPageContainer,
     },
     {
       path: '/student/:username/explorer/career-goals',
@@ -570,7 +555,7 @@ export const routes = {
     {
       path: '/student/:username/explorer/career-goals/:careergoal',
       exact: true,
-      component: ExplorerCareerGoalsPageContainer,
+      component: IndividualExplorerPageContainer,
     },
     {
       path: '/student/:username/explorer/courses',
@@ -580,7 +565,7 @@ export const routes = {
     {
       path: '/student/:username/explorer/courses/:course',
       exact: true,
-      component: ExplorerCoursesPageContainer,
+      component: IndividualExplorerPageContainer,
     },
     {
       path: '/student/:username/explorer/degrees',
@@ -590,7 +575,7 @@ export const routes = {
     {
       path: '/student/:username/explorer/degrees/:degree',
       exact: true,
-      component: ExplorerDegreesPageContainer,
+      component: IndividualExplorerPageContainer,
     },
     {
       path: '/student/:username/explorer/interests',
@@ -600,7 +585,7 @@ export const routes = {
     {
       path: '/student/:username/explorer/interests/:interest',
       exact: true,
-      component: ExplorerInterestsPageContainer,
+      component: IndividualExplorerPageContainer,
     },
     {
       path: '/student/:username/explorer/opportunities',
@@ -610,7 +595,7 @@ export const routes = {
     {
       path: '/student/:username/explorer/opportunities/:opportunity',
       exact: true,
-      component: ExplorerOpportunitiesPageContainer,
+      component: IndividualExplorerPageContainer,
     },
     {
       path: '/student/:username/explorer/users',

--- a/app/imports/ui/components/shared/CardExplorerWidget.tsx
+++ b/app/imports/ui/components/shared/CardExplorerWidget.tsx
@@ -753,11 +753,9 @@ const CardExplorerWidgetCon = connect(mapStateToProps)(CardExplorerWidget);
 const CardExplorerWidgetCont = withTracker((props) => {
   const { collection, type, match } = props;
   const username = match.params.username;
-  // TODO: Test to make sure this is enough to make things reactive
-
   let reactiveSource;
   if (type !== 'users') {
-    reactiveSource = collection.findNonRetired();
+    reactiveSource = collection.findNonRetired({});
   } else {
     reactiveSource = Users.getProfile(username);
   }

--- a/app/imports/ui/components/shared/ExplorerCareerGoalsWidget.tsx
+++ b/app/imports/ui/components/shared/ExplorerCareerGoalsWidget.tsx
@@ -3,24 +3,27 @@ import { Grid, Segment, Header, Button, Divider, Image } from 'semantic-ui-react
 import * as Markdown from 'react-markdown';
 import * as _ from 'lodash';
 import { withTracker } from 'meteor/react-meteor-data';
-import { Link } from 'react-router-dom';
+import { Link, withRouter } from 'react-router-dom';
 import InterestList from './InterestList';
 import { Users } from '../../../api/user/UserCollection';
 import { defaultProfilePicture } from '../../../api/user/BaseProfileCollection';
 import { updateMethod } from '../../../api/base/BaseCollection.methods';
 import { StudentProfiles } from '../../../api/user/StudentProfileCollection';
 
-
 interface IExplorerCareerGoalsWidgetProps {
   name: string;
-  slug: string;
   descriptionPairs: any;
   profile: any;
   item: { [key: string]: any };
   socialPairs: any;
-  id: any;
-  username: string;
-  careerGoal: any;
+  match: {
+    isExact: boolean;
+    path: string;
+    url: string;
+    params: {
+      username: string;
+    }
+  };
 }
 
 class ExplorerCareerGoalsWidget extends React.Component<IExplorerCareerGoalsWidgetProps> {
@@ -40,13 +43,9 @@ See https://github.com/rexxars/react-markdown/issues/29#issuecomment-231556543
 
   private getCareerGoalName = () => this.props.name;
 
-  private getCareerGoal = () => this.props.careerGoal;
-
   private getDescriptionPair = () => this.props.descriptionPairs;
 
   private getSocialPair = () => this.props.socialPairs;
-
-  private getID = () => this.props.id;
 
   private toUpper = (string) => string.toUpperCase();
 
@@ -59,7 +58,7 @@ See https://github.com/rexxars/react-markdown/issues/29#issuecomment-231556543
 
   private userStatus = (careerGoal) => {
     let ret = false;
-    const profile = Users.getProfile(this.props.username);
+    const profile = Users.getProfile(this.props.match.params.username);
     if (_.includes(profile.careerGoalIDs, careerGoal._id)) {
       ret = true;
     }
@@ -68,15 +67,14 @@ See https://github.com/rexxars/react-markdown/issues/29#issuecomment-231556543
 
   private handleAdd = (event) => {
     event.preventDefault();
-    const profile = Users.getProfile(this.props.username);
-    const id = this.getID();
+    const profile = Users.getProfile(this.props.match.params.username);
+    const id = this.props.item._id;
     const studentItems = profile.careerGoalIDs;
     const collectionName = StudentProfiles.getCollectionNameForProfile(profile);
     const updateData: any = {};
     updateData.id = profile._id;
     studentItems.push(id);
     updateData.careerGoals = studentItems;
-    console.log('update', collectionName, updateData);
     updateMethod.call({ collectionName, updateData }, (error) => {
       if (error) {
         console.log('Error updating career goals', error);
@@ -86,15 +84,14 @@ See https://github.com/rexxars/react-markdown/issues/29#issuecomment-231556543
 
   private handleDelete = (event) => {
     event.preventDefault();
-    const profile = Users.getProfile(this.props.username);
-    const id = this.getID();
+    const profile = Users.getProfile(this.props.match.params.username);
+    const id = this.props.item._id;
     let studentItems = profile.careerGoalIDs;
     const collectionName = StudentProfiles.getCollectionNameForProfile(profile);
     const updateData: { [key: string]: any } = {};
     updateData.id = profile._id;
     studentItems = _.without(studentItems, id);
     updateData.careerGoals = studentItems;
-    console.log('update', collectionName, updateData);
     updateMethod.call({ collectionName, updateData }, (error) => {
       if (error) {
         console.log('Error updating career goals', error);
@@ -119,10 +116,9 @@ See https://github.com/rexxars/react-markdown/issues/29#issuecomment-231556543
     };
     const upperName = this.toUpper(this.getCareerGoalName());
     const descriptionPairs = this.getDescriptionPair();
-    const careerGoal = this.getCareerGoal();
     const socialPairs = this.getSocialPair();
     const item = this.props.item;
-    const userStatus = this.userStatus(careerGoal);
+    const userStatus = this.userStatus(item);
     return (
       <Grid container={true} stackable={true} style={marginStyle}>
         <Grid.Column width={16}>
@@ -198,4 +194,4 @@ const ExplorerCareerGoalsWidgetContainer = withTracker((props) => {
     profile,
   };
 })(ExplorerCareerGoalsWidget);
-export default ExplorerCareerGoalsWidgetContainer;
+export default withRouter(ExplorerCareerGoalsWidgetContainer);

--- a/app/imports/ui/components/shared/ExplorerCareerGoalsWidget.tsx
+++ b/app/imports/ui/components/shared/ExplorerCareerGoalsWidget.tsx
@@ -9,11 +9,11 @@ import { Users } from '../../../api/user/UserCollection';
 import { defaultProfilePicture } from '../../../api/user/BaseProfileCollection';
 import { updateMethod } from '../../../api/base/BaseCollection.methods';
 import { StudentProfiles } from '../../../api/user/StudentProfileCollection';
+import { IProfile } from '../../../typings/radgrad'; // eslint-disable-line
 
 interface IExplorerCareerGoalsWidgetProps {
   name: string;
   descriptionPairs: any;
-  profile: any;
   item: { [key: string]: any };
   socialPairs: any;
   match: {
@@ -24,6 +24,7 @@ interface IExplorerCareerGoalsWidgetProps {
       username: string;
     }
   };
+  profile: IProfile;
 }
 
 class ExplorerCareerGoalsWidget extends React.Component<IExplorerCareerGoalsWidgetProps> {
@@ -31,21 +32,11 @@ class ExplorerCareerGoalsWidget extends React.Component<IExplorerCareerGoalsWidg
     super(props);
   }
 
-  /*
-Because we are using react-router, the converted markdown hyperlinks won't be redirected properly. This is a solution.
-See https://github.com/rexxars/react-markdown/issues/29#issuecomment-231556543
-*/
   private routerLink = (props) => (
     props.href.match(/^(https?:)?\/\//)
       ? <a href={props.href}>{props.children}</a>
       : <Link to={props.href}>{props.children}</Link>
   )
-
-  private getCareerGoalName = () => this.props.name;
-
-  private getDescriptionPair = () => this.props.descriptionPairs;
-
-  private getSocialPair = () => this.props.socialPairs;
 
   private toUpper = (string) => string.toUpperCase();
 
@@ -114,11 +105,10 @@ See https://github.com/rexxars/react-markdown/issues/29#issuecomment-231556543
       marginTop: 0,
       padding: 0,
     };
-    const upperName = this.toUpper(this.getCareerGoalName());
-    const descriptionPairs = this.getDescriptionPair();
-    const socialPairs = this.getSocialPair();
-    const item = this.props.item;
+    const { name, descriptionPairs, socialPairs, item } = this.props;
+    const upperName = this.toUpper(name);
     const userStatus = this.userStatus(item);
+
     return (
       <Grid container={true} stackable={true} style={marginStyle}>
         <Grid.Column width={16}>
@@ -155,7 +145,6 @@ See https://github.com/rexxars/react-markdown/issues/29#issuecomment-231556543
                       </React.Fragment>
                       : ''
                   }
-
                   {
                     this.isLabel(descriptionPair.label, 'Interests') ?
                       <div style={{ marginTop: '5px' }}>
@@ -189,7 +178,8 @@ See https://github.com/rexxars/react-markdown/issues/29#issuecomment-231556543
 }
 
 const ExplorerCareerGoalsWidgetContainer = withTracker((props) => {
-  const profile = Users.getProfile(props.username);
+  const profile = Users.getProfile(props.match.params.username);
+
   return {
     profile,
   };

--- a/app/imports/ui/components/shared/ExplorerConstants.ts
+++ b/app/imports/ui/components/shared/ExplorerConstants.ts
@@ -1,0 +1,9 @@
+export const EXPLORER_TYPE = {
+  ACADEMICPLAN: 'plans',
+  CAREERGOAL: 'career-goals',
+  COURSES: 'courses',
+  DEGREES: 'degrees',
+  INTERESTS: 'interests',
+  OPPORTUNITIES: 'opportunities',
+  USERS: 'users',
+};

--- a/app/imports/ui/components/shared/ExplorerCoursesWidget.tsx
+++ b/app/imports/ui/components/shared/ExplorerCoursesWidget.tsx
@@ -20,12 +20,9 @@ import { UserInteractions } from '../../../api/analytic/UserInteractionCollectio
 interface IExplorerCoursesWidgetProps {
   name: string;
   shortName: string;
-  slug: string;
   descriptionPairs: any[];
-  id: string;
   item: ICourse;
   completed: boolean;
-  reviewed: boolean;
   role: string;
   match: {
     isExact: boolean;

--- a/app/imports/ui/components/shared/ExplorerDegreesWidget.tsx
+++ b/app/imports/ui/components/shared/ExplorerDegreesWidget.tsx
@@ -5,11 +5,7 @@ import * as Markdown from 'react-markdown';
 
 interface IExplorerDegreesWidgetProps {
   name: string;
-  slug: string;
   descriptionPairs: any;
-  socialPairs: object[];
-  id: string;
-  item: object;
 }
 
 class ExplorerDegreesWidget extends React.Component<IExplorerDegreesWidgetProps> {

--- a/app/imports/ui/components/shared/ExplorerMenu.tsx
+++ b/app/imports/ui/components/shared/ExplorerMenu.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Dropdown, Menu, Header, Responsive, Button, Icon } from 'semantic-ui-react';
 import { NavLink, withRouter, Link } from 'react-router-dom';
 import * as _ from 'lodash';
+import { withTracker } from 'meteor/react-meteor-data';
 import {
   IAcademicPlan, //eslint-disable-line
   ICareerGoal, //eslint-disable-line
@@ -9,11 +10,13 @@ import {
   IDesiredDegree, //eslint-disable-line
   IInterest, //eslint-disable-line
   IOpportunity, //eslint-disable-line
+  IProfile, // eslint-disable-line
 } from '../../../typings/radgrad';
 import { Users } from '../../../api/user/UserCollection';
 import { CourseInstances } from '../../../api/course/CourseInstanceCollection';
 import { OpportunityInstances } from '../../../api/opportunity/OpportunityInstanceCollection';
 import { Slugs } from '../../../api/slug/SlugCollection';
+import * as Router from './RouterHelperFunctions';
 
 type explorerInterfaces = IAcademicPlan | ICareerGoal | ICourse | IDesiredDegree | IInterest | IOpportunity;
 
@@ -30,6 +33,7 @@ interface IExplorerMenuProps {
       username: string;
     }
   };
+  profile: IProfile;
 }
 
 // FIXME: Needs to be reactive
@@ -538,4 +542,12 @@ class ExplorerMenu extends React.Component<IExplorerMenuProps> {
   }
 }
 
-export default withRouter(ExplorerMenu);
+export const ExplorerMenuCon = withTracker((props) => {
+  const username = Router.getUsername(props.match);
+  const profile = Users.getProfile(username);
+  return {
+    profile,
+  };
+})(ExplorerMenu);
+export const ExplorerMenuContainer = withRouter(ExplorerMenuCon);
+export default ExplorerMenuContainer;

--- a/app/imports/ui/components/shared/ExplorerOpportunitiesWidget.tsx
+++ b/app/imports/ui/components/shared/ExplorerOpportunitiesWidget.tsx
@@ -19,12 +19,9 @@ import StudentExplorerOpportunitiesWidgetButton from '../student/StudentExplorer
 
 interface IExplorerOpportunitiesWidgetProps {
   name: string;
-  slug: string;
   descriptionPairs: any[];
-  id: string;
   item: IOpportunity
   completed: boolean;
-  reviewed: boolean;
   role: string;
   match: {
     isExact: boolean;

--- a/app/imports/ui/components/shared/ExplorerPlansWidget.tsx
+++ b/app/imports/ui/components/shared/ExplorerPlansWidget.tsx
@@ -13,7 +13,6 @@ import { updateMethod } from '../../../api/base/BaseCollection.methods';
 interface IExplorerPlansWidgetProps {
   name: string;
   descriptionPairs: any[];
-  id: string;
   item: IAcademicPlan;
   role: string;
   profile: object;

--- a/app/imports/ui/components/shared/ProfileAdd.tsx
+++ b/app/imports/ui/components/shared/ProfileAdd.tsx
@@ -7,6 +7,7 @@ import { StudentProfiles } from '../../../api/user/StudentProfileCollection';
 import { FacultyProfiles } from '../../../api/user/FacultyProfileCollection';
 import { MentorProfiles } from '../../../api/user/MentorProfileCollection';
 import { Users } from '../../../api/user/UserCollection';
+import { EXPLORER_TYPE } from './ExplorerConstants';
 
 interface IProfileAddProps {
   item: IAcademicPlan;
@@ -50,13 +51,13 @@ class ProfileAdd extends React.Component<IProfileAddProps> {
       } else {
         collectionName = MentorProfiles.getCollectionName();
       }
-      if (type === 'careergoals') {
+      if (type === EXPLORER_TYPE.CAREERGOAL) {
         updateData.careerGoals = profile.careerGoalIDs;
         updateData.careerGoals.push(item._id);
-      } else if (type === 'interests') {
+      } else if (type === EXPLORER_TYPE.CAREERGOAL) {
         updateData.interests = profile.interestIDs;
         updateData.interests.push(item._id);
-      } else if (type === 'plans') {
+      } else if (type === EXPLORER_TYPE.ACADEMICPLAN) {
         updateData.academicPlan = item._id;
       }
       updateMethod.call({ collectionName, updateData }, (error) => {

--- a/app/imports/ui/components/shared/ProfileCard.tsx
+++ b/app/imports/ui/components/shared/ProfileCard.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { _ } from 'meteor/erasaur:meteor-lodash';
 import { withRouter, Link } from 'react-router-dom';
-import { Button, Card, Icon } from 'semantic-ui-react';
+import { Card, Icon } from 'semantic-ui-react';
 import Swal from 'sweetalert2';
 import * as Markdown from 'react-markdown';
 import { Slugs } from '../../../api/slug/SlugCollection';
@@ -10,6 +10,7 @@ import { Users } from '../../../api/user/UserCollection';
 import { updateMethod } from '../../../api/base/BaseCollection.methods';
 import { FacultyProfiles } from '../../../api/user/FacultyProfileCollection';
 import { MentorProfiles } from '../../../api/user/MentorProfileCollection';
+import ProfileAdd from './ProfileAdd';
 
 
 interface IProfileCardProps {
@@ -118,8 +119,8 @@ class ProfileCard extends React.Component<IProfileCardProps> {
     let name;
     switch (this.getRoleByUrl()) {
       case 'student':
-       name = StudentProfiles.getCollectionName();
-       break;
+        name = StudentProfiles.getCollectionName();
+        break;
       case 'faculty':
         name = FacultyProfiles.getCollectionName();
         break;
@@ -132,7 +133,6 @@ class ProfileCard extends React.Component<IProfileCardProps> {
       default:
         break;
     }
-    console.log('get collection name', name);
     return name;
 
   };
@@ -172,10 +172,11 @@ class ProfileCard extends React.Component<IProfileCardProps> {
    * a type, a canAdd method that returns true and match
    */
   public render(): React.ReactElement<any> | string | number | {} | React.ReactNodeArray | React.ReactPortal | boolean | null | undefined {
-    const { item } = this.props;
+    const { item, type, canAdd } = this.props;
     const itemName = this.itemName(item);
     const itemShortDescription = this.itemShortDescription(item);
     const itemParticipation = this.studentsParticipating(item);
+
     return (
       <Card className='radgrad-interest-card'>
         <Card.Content>
@@ -190,15 +191,11 @@ class ProfileCard extends React.Component<IProfileCardProps> {
         </Card.Content>
         <div className="radgrad-home-buttons ui center aligned two bottom attached buttons">
           <Link to={this.buildRouteName(this.props.item)} className='ui button'>
-            <Icon name='chevron circle right'></Icon>
+            <Icon name='chevron circle right'/>
             <br/>
             View More
           </Link>
-          <Button className="radgrad-home-buttons center aligned" attatched="bottom" onClick={this.handleClick}
-                  fluid><Icon
-            name="plus"></Icon>
-            <br/>Add to
-            Interests</Button>
+          {canAdd && <ProfileAdd item={item} type={type}/>}
         </div>
       </Card>
 

--- a/app/imports/ui/components/shared/RouterHelperFunctions.tsx
+++ b/app/imports/ui/components/shared/RouterHelperFunctions.tsx
@@ -85,6 +85,52 @@ export const getRoleByUrl = (match: IMatchProps): string => {
   return role;
 };
 
+// The  roles by URL (i.e. /student/abi@hawaii.edu (student being the URL role))
+export const URL_ROLE = {
+  ADMIN: 'admin',
+  ADVISOR: 'advisor',
+  ALUMNI: 'alumni',
+  FACULTY: 'faculty',
+  MENTOR: 'mentor',
+  STUDENT: 'student',
+};
+
+// Returns if the role by URL is Admin
+export const isUrlRoleAdmin = (match: IMatchProps): boolean => {
+  const role = getRoleByUrl(match);
+  return role === URL_ROLE.ADMIN;
+};
+
+// Returns if the role by URL is Advisor
+export const isUrlRoleAdvisor = (match: IMatchProps): boolean => {
+  const role = getRoleByUrl(match);
+  return role === URL_ROLE.ADVISOR;
+};
+
+// Returns if the role by URL is Alumni
+export const isUrlRoleAlumni = (match: IMatchProps): boolean => {
+  const role = getRoleByUrl(match);
+  return role === URL_ROLE.ALUMNI;
+};
+
+// Returns if the role by URL is Faculty
+export const isUrlRoleFaculty = (match: IMatchProps): boolean => {
+  const role = getRoleByUrl(match);
+  return role === URL_ROLE.FACULTY;
+};
+
+// Returns if the role by URL is Mentor
+export const isUrlRoleMentor = (match: IMatchProps): boolean => {
+  const role = getRoleByUrl(match);
+  return role === URL_ROLE.MENTOR;
+};
+
+// Returns if the role by URL is Student
+export const isUrlRoleStudent = (match: IMatchProps): boolean => {
+  const role = getRoleByUrl(match);
+  return role === URL_ROLE.STUDENT;
+};
+
 // Renders the Page Menu Widget based on the role.
 export const renderPageMenuWidget = (match: IMatchProps): JSX.Element => {
   const role = getRoleByUrl(match);

--- a/app/imports/ui/components/shared/RouterHelperFunctions.tsx
+++ b/app/imports/ui/components/shared/RouterHelperFunctions.tsx
@@ -46,6 +46,14 @@ export const getBaseRoute = (match: IMatchProps): string => {
   return baseRoute;
 };
 
+// Builds a route name and returns it. Make sure routeName is preceeded by a forward slash ('/').
+// i.e., buildRouteName('/explorer/plans') => /role/:username/explorer/plans
+export const buildRouteName = (match: IMatchProps, routeName: string): string => {
+  const baseRoute = getBaseRoute(match);
+  const route = `${baseRoute}${routeName}`;
+  return route;
+};
+
 // Returns the parameter by index (the parameters AFTER the base route)
 // i.e., /student/abi@hawaii.edu/param1/param2/param3 (index = 1 returns param1, index = 2 returns param2, etc...)
 export const getUrlParam = (match: IMatchProps, index: number) => {

--- a/app/imports/ui/components/shared/RouterHelperFunctions.tsx
+++ b/app/imports/ui/components/shared/RouterHelperFunctions.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import { Users } from '../../../api/user/UserCollection';
+import StudentPageMenuWidget from '../student/StudentPageMenuWidget';
+import MentorPageMenuWidget from '../mentor/MentorPageMenuWidget';
+import FacultyPageMenuWidget from '../faculty/FacultyPageMenuWidget';
+import AdminPageMenuWidget from '../admin/AdminPageMenuWidget';
+import AdvisorPageMenuWidget from '../advisor/AdvisorPageMenuWidget';
+import AlumniPageMenuWidget from '../alumni/AlumniPageMenuWidget';
+
+interface IMatchProps {
+  isExact: boolean;
+  path: string;
+  url: string;
+  params?: {
+    username: string;
+  }
+}
+
+export const getUsername = (match: IMatchProps): string => match.params.username;
+
+export const getUserIdFromRoute = (match: IMatchProps): string => {
+  const username = getUsername(match);
+  return username && Users.getID(username);
+};
+
+/*
+ * Returns the type of the CARD explorer page. Should only be called from Card Explorer.
+ * (i.e., explorer/plans, explorer/courses), NOT individual explorers (i.e. /explorer/courses/ics_111)
+ */
+export const getCardExplorerType = (match: IMatchProps): string => {
+  const url = match.url;
+  const index = url.lastIndexOf('/');
+  return url.substr(index + 1);
+};
+
+/*
+ * Returns the type of the INDIVIDUAL explorer page. Should only be called from Individual Explorers.
+ * (i.e. /explorer/courses/ics_111), NOT card explorers (i.e., explorer/plans, explorer/courses)
+ */
+export const getIndividualExplorerType = (match: IMatchProps): string => {
+  const url = match.url;
+  const index = url.lastIndexOf('/');
+  return url.substr(index + 2);
+};
+
+export const getRoleByUrl = (match: IMatchProps): string => {
+  const url = match.url;
+  const username = getUsername(match);
+  const indexUsername = url.indexOf(username);
+  return url.substring(1, indexUsername - 1);
+};
+
+export const renderPageMenuWidget = (match: IMatchProps): JSX.Element => {
+  const role = getRoleByUrl(match);
+  switch (role) {
+    case 'admin':
+      return <AdminPageMenuWidget/>;
+    case 'advisor':
+      return <AdvisorPageMenuWidget/>;
+    case 'alumni':
+      return <AlumniPageMenuWidget/>;
+    case 'faculty':
+      return <FacultyPageMenuWidget/>;
+    case 'mentor':
+      return <MentorPageMenuWidget/>;
+    case 'student':
+      return <StudentPageMenuWidget/>;
+    default:
+      return <React.Fragment/>;
+  }
+};

--- a/app/imports/ui/components/shared/RouterHelperFunctions.tsx
+++ b/app/imports/ui/components/shared/RouterHelperFunctions.tsx
@@ -16,40 +16,68 @@ interface IMatchProps {
   }
 }
 
+// Returns the USERNAME param based on React-Router's match object
 export const getUsername = (match: IMatchProps): string => match.params.username;
 
+// Returns the User ID based off of the USERNAME param
 export const getUserIdFromRoute = (match: IMatchProps): string => {
   const username = getUsername(match);
   return username && Users.getID(username);
 };
 
-/*
- * Returns the type of the CARD explorer page. Should only be called from Card Explorer.
- * (i.e., explorer/plans, explorer/courses), NOT individual explorers (i.e. /explorer/courses/ics_111)
- */
-export const getCardExplorerType = (match: IMatchProps): string => {
-  const url = match.url;
-  const index = url.lastIndexOf('/');
-  return url.substr(index + 1);
+// Returns the URL based on React-Router's match object.
+export const getUrl = (match: IMatchProps): string => match.url;
+
+// Slits the URL into an array of parameter strings.
+// i.e., /student/abi@hawaii.edu/explorer => ["", "student", "abi@hawaii.edu", "explorer"]
+export const splitUrlIntoArray = (match: IMatchProps): string[] => {
+  const url = getUrl(match);
+  return url.split('/');
 };
 
-/*
- * Returns the type of the INDIVIDUAL explorer page. Should only be called from Individual Explorers.
- * (i.e. /explorer/courses/ics_111), NOT card explorers (i.e., explorer/plans, explorer/courses)
- */
-export const getIndividualExplorerType = (match: IMatchProps): string => {
-  const url = match.url;
-  const index = url.lastIndexOf('/');
-  return url.substr(index + 2);
+// Returns the base route of the URL (role + username)
+// i.e. /student/abi@hawaii.edu
+// Note, this function does NOT add a ending forward slash.
+export const getBaseRoute = (match: IMatchProps): string => {
+  const username = match.params.username;
+  const baseUrl = match.url;
+  const baseIndex = baseUrl.indexOf(username);
+  const baseRoute = `${baseUrl.substring(0, baseIndex)}${username}`;
+  return baseRoute;
 };
 
+// Returns the parameter by index (the parameters AFTER the base route)
+// i.e., /student/abi@hawaii.edu/param1/param2/param3 (index = 1 returns param1, index = 2 returns param2, etc...)
+export const getUrlParam = (match: IMatchProps, index: number) => {
+  if (index <= 0) {
+    throw new Error('getUrlParam() function from RouterHelperFunctions.tsx requires index to be greater than 0');
+  }
+  const parameters = splitUrlIntoArray(match);
+  const username = getUsername(match);
+  const usernameIndex = parameters.indexOf(username);
+  const param = parameters[usernameIndex + index];
+  return param;
+};
+
+// Returns the last param of the URL
+// i.e., /student/abi@hawaii/edu/param1/param2/param3/param4 => param4
+export const getLastUrlParam = (match: IMatchProps): string => {
+  const parameters = splitUrlIntoArray(match);
+  const lastParam = parameters[parameters.length - 1];
+  return lastParam;
+};
+
+// Returns the role of the USERNAME of the url
+// i.e., /mentor/somementor@hawaii.edu => mentor
 export const getRoleByUrl = (match: IMatchProps): string => {
   const url = match.url;
   const username = getUsername(match);
   const indexUsername = url.indexOf(username);
-  return url.substring(1, indexUsername - 1);
+  const role = url.substring(1, indexUsername - 1);
+  return role;
 };
 
+// Renders the Page Menu Widget based on the role.
 export const renderPageMenuWidget = (match: IMatchProps): JSX.Element => {
   const role = getRoleByUrl(match);
   switch (role) {

--- a/app/imports/ui/pages/shared/CardExplorerPage.tsx
+++ b/app/imports/ui/pages/shared/CardExplorerPage.tsx
@@ -23,7 +23,7 @@ import { StudentProfiles } from '../../../api/user/StudentProfileCollection';
 import { ROLE } from '../../../api/role/Role';
 import { OpportunityInstances } from '../../../api/opportunity/OpportunityInstanceCollection';
 import HelpPanelWidget from '../../components/shared/HelpPanelWidget';
-import { HelpMessages } from '../../../api/help/HelpMessageCollection';
+import * as Router from '../../components/shared/RouterHelperFunctions';
 
 interface ICardExplorerPageProps {
   match: {
@@ -325,7 +325,7 @@ class CardExplorerPage extends React.Component<ICardExplorerPageProps> {
   }
 
   public render(): React.ReactElement<any> | string | number | {} | React.ReactNodeArray | React.ReactPortal | boolean | null | undefined {
-    const helpMessage = HelpMessages.findOne({ routeName: this.props.match.path });
+    const menuWidget = Router.renderPageMenuWidget(this.props.match);
 
     const addedList = this.getAddedList();
     const isTypeInterest = this.getType() === 'interests'; // Only Interests takes in Career List for CardExplorerMenu
@@ -334,13 +334,11 @@ class CardExplorerPage extends React.Component<ICardExplorerPageProps> {
 
     return (
       <React.Fragment>
-
-        {this.renderPageMenuWidget()}
-
+        {menuWidget}
 
         <Grid container={true} stackable={true}>
           <Grid.Row>
-            {helpMessage ? <HelpPanelWidget/> : ''}
+            <HelpPanelWidget/>
           </Grid.Row>
 
           <Grid.Column width={3}>

--- a/app/imports/ui/pages/shared/CardExplorerPage.tsx
+++ b/app/imports/ui/pages/shared/CardExplorerPage.tsx
@@ -41,18 +41,11 @@ class CardExplorerPage extends React.Component<ICardExplorerPageProps> {
     super(props);
   }
 
-  private getUsername = (): string => this.props.match.params.username;
+  private getUsername = (): string => Router.getUsername(this.props.match);
 
-  private getUserIdFromRoute = (): string => {
-    const username = this.getUsername();
-    return username && Users.getID(username);
-  }
+  private getUserIdFromRoute = (): string => Router.getUserIdFromRoute(this.props.match);
 
-  private getType = (): string => {
-    const url = this.props.match.url;
-    const index = url.lastIndexOf('/');
-    return url.substr(index + 1);
-  }
+  private getType = (): string => Router.getLastUrlParam(this.props.match);
 
   private getCollection = (): object => {
     const type = this.getType();

--- a/app/imports/ui/pages/shared/ExplorerCareerGoalsPage.tsx
+++ b/app/imports/ui/pages/shared/ExplorerCareerGoalsPage.tsx
@@ -86,7 +86,6 @@ class ExplorerCareerGoalsPage extends React.Component<IExplorerCareerGoalsPagePr
     const careerGoal = this.careerGoal();
     const username = this.props.match.params.username;
     const careerName = careerGoal.name;
-    const slugName = careerGoal.slugID;
     const socialPairs = this.socialPairs(careerGoal);
     const descriptionPairs = this.descriptionPairs(careerGoal);
     return (
@@ -96,9 +95,8 @@ class ExplorerCareerGoalsPage extends React.Component<IExplorerCareerGoalsPagePr
         </Grid.Column>
 
         <Grid.Column width={13}>
-          <ExplorerCareerGoalsWidgetContainer name={careerName} slug={slugName} descriptionPairs={descriptionPairs}
-                                              item={careerGoal} socialPairs={socialPairs} id={careerGoal._id}
-                                              username={username} careerGoal={careerGoal}/>
+          <ExplorerCareerGoalsWidgetContainer name={careerName} descriptionPairs={descriptionPairs}
+                                              item={careerGoal} socialPairs={socialPairs} username={username}/>
         </Grid.Column>
       </Grid>
     );

--- a/app/imports/ui/pages/shared/ExplorerCoursesPage.tsx
+++ b/app/imports/ui/pages/shared/ExplorerCoursesPage.tsx
@@ -12,7 +12,6 @@ import { Interests } from '../../../api/interest/InterestCollection';
 import { isSingleChoice } from '../../../api/degree-plan/PlanChoiceUtilities';
 import { Users } from '../../../api/user/UserCollection';
 import { CourseInstances } from '../../../api/course/CourseInstanceCollection';
-import { Reviews } from '../../../api/review/ReviewCollection';
 import ExplorerCoursesWidget from '../../components/shared/ExplorerCoursesWidget';
 import { ICourse } from '../../../typings/radgrad'; // eslint-disable-line
 import HelpPanelWidget from '../../components/shared/HelpPanelWidget';
@@ -85,8 +84,6 @@ class ExplorerCoursesPage extends React.Component<IExplorerCoursesPageProps> {
     const course = Courses.findDoc({ slugID: slug[0]._id });
     return course;
   }
-
-  private slugName = (slugID: string): string => Slugs.findDoc(slugID).name;
 
   private descriptionPairs = (course: ICourse): object[] => [
     { label: 'Course Number', value: course.num },
@@ -166,18 +163,6 @@ class ExplorerCoursesPage extends React.Component<IExplorerCoursesPageProps> {
     return ret;
   }
 
-  private reviewed = (course: ICourse): boolean => {
-    let ret = false;
-    const review = Reviews.find({
-      studentID: this.getUserIdFromRoute(),
-      revieweeID: course._id,
-    }).fetch();
-    if (review.length > 0) {
-      ret = true;
-    }
-    return ret;
-  }
-
   private getUserIdFromRoute = (): string => {
     const username = this.props.match.params.username;
     return username && Users.getID(username);
@@ -191,11 +176,8 @@ class ExplorerCoursesPage extends React.Component<IExplorerCoursesPageProps> {
     const course = this.course();
     const name = course.name;
     const shortName = course.shortName;
-    const slug = this.slugName(course.slugID);
     const descriptionPairs = this.descriptionPairs(course);
-    const id = course._id;
     const completed = this.completed();
-    const reviewed = this.reviewed(course);
     const role = this.getRoleByUrl();
 
     return (
@@ -212,8 +194,8 @@ class ExplorerCoursesPage extends React.Component<IExplorerCoursesPageProps> {
           </Grid.Column>
 
           <Grid.Column width={13}>
-            <ExplorerCoursesWidget name={name} shortName={shortName} slug={slug} descriptionPairs={descriptionPairs}
-                                   id={id} item={course} completed={completed} reviewed={reviewed} role={role}/>
+            <ExplorerCoursesWidget name={name} shortName={shortName} descriptionPairs={descriptionPairs} role={role}
+                                   item={course} completed={completed}/>
           </Grid.Column>
         </Grid>
       </React.Fragment>

--- a/app/imports/ui/pages/shared/ExplorerDegreesPage.tsx
+++ b/app/imports/ui/pages/shared/ExplorerDegreesPage.tsx
@@ -63,7 +63,7 @@ class ExplorerDegreesPage extends React.Component<IExplorerDegreesPageProps> {
   }))
 
   /* ####################################### EXPLORER DEGREES WIDGET HELPER FUNCTIONS ############################### */
-  private degree = () => {
+  private degree = (): IDesiredDegree => {
     const degreeSlugName = this.props.match.params.degree;
     const slug = Slugs.find({ name: degreeSlugName }).fetch();
     const degree = DesiredDegrees.findNonRetired({ slugID: slug[0]._id });
@@ -103,10 +103,7 @@ class ExplorerDegreesPage extends React.Component<IExplorerDegreesPageProps> {
 
     const degree = this.degree();
     const name = degree.name;
-    const slug = this.slugName(degree.slugID);
     const descriptionPairs = this.descriptionPairs(degree);
-    const socialPairs = this.socialPairs(degree);
-    const id = degree._id;
 
     return (
       <React.Fragment>
@@ -122,8 +119,7 @@ class ExplorerDegreesPage extends React.Component<IExplorerDegreesPageProps> {
           </Grid.Column>
 
           <Grid.Column width={13}>
-            <ExplorerDegreesWidget name={name} slug={slug} descriptionPairs={descriptionPairs} socialPairs={socialPairs}
-                                   id={id} item={degree}/>
+            <ExplorerDegreesWidget name={name} descriptionPairs={descriptionPairs}/>
           </Grid.Column>
         </Grid>
       </React.Fragment>

--- a/app/imports/ui/pages/shared/ExplorerOpportunitiesPage.tsx
+++ b/app/imports/ui/pages/shared/ExplorerOpportunitiesPage.tsx
@@ -182,12 +182,8 @@ class ExplorerOpportunitiesPage extends React.Component<IExplorerOpportunitiesPa
 
     const opportunity = this.opportunity();
     const name = opportunity.name;
-    const slug = this.slugName(opportunity.slugID);
     const descriptionPairs = this.descriptionPairs(opportunity);
-    const id = opportunity._id;
-    const socialPairs = this.socialPairs(opportunity);
     const completed = this.completed();
-    const reviewed = this.reviewed(opportunity);
     const role = this.getRoleByUrl();
     return (
       <React.Fragment>
@@ -203,9 +199,8 @@ class ExplorerOpportunitiesPage extends React.Component<IExplorerOpportunitiesPa
           </Grid.Column>
 
           <Grid.Column width={13}>
-            <ExplorerOpportunitiesWidget name={name} slug={slug} descriptionPairs={descriptionPairs} id={id} role={role}
-                                         item={opportunity} socialPairs={socialPairs} completed={completed}
-                                         reviewed={reviewed}/>
+            <ExplorerOpportunitiesWidget name={name} descriptionPairs={descriptionPairs} role={role} item={opportunity}
+                                         completed={completed}/>
           </Grid.Column>
         </Grid>
       </React.Fragment>

--- a/app/imports/ui/pages/shared/ExplorerPlansPage.tsx
+++ b/app/imports/ui/pages/shared/ExplorerPlansPage.tsx
@@ -66,7 +66,7 @@ class ExplorerPlansPage extends React.Component<IExplorerPlansPageProps> {
 
   /* ####################################### EXPLORER PLANS WIDGET HELPER FUNCTIONS ############################### */
 
-  private plan() {
+  private plan = (): IAcademicPlan => {
     const planSlugName = this.props.match.params.plan;
     const slug = Slugs.findDoc({ name: planSlugName });
     return AcademicPlans.findDoc({ slugID: slug._id });
@@ -93,7 +93,6 @@ class ExplorerPlansPage extends React.Component<IExplorerPlansPageProps> {
     const plan = this.plan();
     const name = plan.name;
     const descriptionPairs = this.descriptionPairs(plan);
-    const id = plan._id;
 
     return (
       <React.Fragment>
@@ -109,7 +108,7 @@ class ExplorerPlansPage extends React.Component<IExplorerPlansPageProps> {
           </Grid.Column>
 
           <Grid.Column width={13}>
-            <ExplorerPlansWidget name={name} descriptionPairs={descriptionPairs} id={id} item={plan}
+            <ExplorerPlansWidget name={name} descriptionPairs={descriptionPairs} item={plan}
                                  role={this.getRoleByUrl()}/>
           </Grid.Column>
         </Grid>

--- a/app/imports/ui/pages/shared/IndividualExplorerPage.tsx
+++ b/app/imports/ui/pages/shared/IndividualExplorerPage.tsx
@@ -20,7 +20,15 @@ import ExplorerOpportunitiesWidget from '../../components/shared/ExplorerOpportu
 import ExplorerDegreesWidget from '../../components/shared/ExplorerDegreesWidget';
 import ExplorerCoursesWidget from '../../components/shared/ExplorerCoursesWidget';
 import ExplorerInterestsWidget from '../../components/shared/ExplorerInterestsWidget';
+import ExplorerCareerGoalsWidget from '../../components/shared/ExplorerCareerGoalsWidget';
 import { Slugs } from '../../../api/slug/SlugCollection';
+import { ROLE } from '../../../api/role/Role';
+import { isSingleChoice } from '../../../api/degree-plan/PlanChoiceUtilities';
+import { OpportunityTypes } from '../../../api/opportunity/OpportunityTypeCollection';
+import { AcademicTerms } from '../../../api/academic-term/AcademicTermCollection';
+import { Teasers } from '../../../api/teaser/TeaserCollection';
+import withGlobalSubscription from '../../layouts/shared/GlobalSubscriptionsHOC';
+import withInstanceSubscriptions from '../../layouts/shared/InstanceSubscriptionsHOC';
 
 interface IIndividualExplorerPageProps {
   match: {
@@ -44,7 +52,13 @@ class IndividualExplorerPage extends React.Component<IIndividualExplorerPageProp
     super(props);
   }
 
-  private getType = (): string => Router.getIndividualExplorerType(this.props.match);
+  private getType = (): string => Router.getUrlParam(this.props.match, 2);
+
+  private getSlug = (): string => Router.getLastUrlParam(this.props.match);
+
+  private getRole = (): string => Router.getRoleByUrl(this.props.match);
+
+  private getMenuWidget = (): JSX.Element => Router.renderPageMenuWidget(this.props.match);
 
   /* ################################################# EXPLORER MENU HELPER FUNCTIONS ############################### */
   private getAddedList = (): { [key: string]: any }[] => {
@@ -102,6 +116,28 @@ class IndividualExplorerPage extends React.Component<IIndividualExplorerPageProp
     }
   }
 
+  private getDescriptionPairs = (item: { [key: string]: any }): object[] => {
+    const type = this.getType();
+    switch (type) {
+      case 'plans':
+        return this.descriptionPairsPlans(item as IAcademicPlan);
+      case 'career-goals':
+        return this.descriptionPairsCareerGoals(item as ICareerGoal);
+      case 'courses':
+        return this.descriptionPairsCourses(item as ICourse);
+      case 'degrees':
+        return this.descriptionPairsDegrees(item as IDesiredDegree);
+      case 'interests':
+        return undefined; // Quinne implemented the descriptionPairs into their own components
+      case 'opportunities':
+        return this.descriptionPairsOpportunities(item as IOpportunity);
+      case 'users': // do nothing
+        return undefined;
+      default:
+        return undefined;
+    }
+  }
+
   /* ################################################# ACADEMIC PLAN HELPER FUNCTIONS ############################### */
   private addedPlans = (): { item: IAcademicPlan, count: number }[] => {
     const profile = Users.getProfile(Router.getUsername(this.props.match));
@@ -117,6 +153,14 @@ class IndividualExplorerPage extends React.Component<IIndividualExplorerPageProp
     return AcademicPlans.findDoc({ slugID: slug._id });
   }
 
+  private descriptionPairsPlans = (plan: IAcademicPlan): { label: string, value: any }[] => {
+    const degree = DesiredDegrees.findDoc(plan.degreeID);
+    const description = `${degree.description}\n\n${plan.description}`;
+    return [
+      { label: 'Description', value: description },
+    ];
+  }
+
   /* ################################################# CAREER GOALS HELPER FUNCTIONS ################################ */
   private addedCareerGoals = (): { item: ICareerGoal, count: number }[] => {
     const addedCareerGoals = [];
@@ -129,6 +173,51 @@ class IndividualExplorerPage extends React.Component<IIndividualExplorerPageProp
     });
     return addedCareerGoals;
   }
+
+  private careerGoal = (): ICareerGoal => {
+    const careerGoalSlugName = this.props.match.params.careergoal;
+    const slug = Slugs.find({ name: careerGoalSlugName }).fetch();
+    const careerGoal = CareerGoals.find({ slugID: slug[0]._id }).fetch();
+    return careerGoal[0];
+  }
+
+  private descriptionPairsCareerGoals = (careerGoal: ICareerGoal): { label: string, value: any }[] => [
+    { label: 'Description', value: careerGoal.description },
+    { label: 'Interests', value: _.sortBy(Interests.findNames(careerGoal.interestIDs)) },
+  ]
+
+  private socialPairsCareerGoals = (careerGoal: ICareerGoal): { label: string, amount: number, value: any }[] => [
+    {
+      label: 'students', amount: this.numUsersCareerGoals(careerGoal, ROLE.STUDENT),
+      value: this.interestedUsersCareerGoals(careerGoal, ROLE.STUDENT),
+    },
+    {
+      label: 'faculty members', amount: this.numUsersCareerGoals(careerGoal, ROLE.FACULTY),
+      value: this.interestedUsersCareerGoals(careerGoal, ROLE.FACULTY),
+    },
+    {
+      label: 'alumni',
+      amount: this.numUsersCareerGoals(careerGoal, ROLE.ALUMNI),
+      value: this.interestedUsersCareerGoals(careerGoal, ROLE.ALUMNI),
+    },
+    {
+      label: 'mentors',
+      amount: this.numUsersCareerGoals(careerGoal, ROLE.MENTOR),
+      value: this.interestedUsersCareerGoals(careerGoal, ROLE.MENTOR),
+    },
+  ]
+
+  private interestedUsersCareerGoals = (careerGoal: ICareerGoal, role: string): object[] => {
+    const interested = [];
+    const profiles = Users.findProfilesWithRole(role, {}, {});
+    _.forEach(profiles, (profile) => {
+      if (_.includes(profile.careerGoalIDs, careerGoal._id)) {
+        interested.push(profile);
+      }
+    });
+    return interested;
+  }
+  private numUsersCareerGoals = (careerGoal: ICareerGoal, role: string): number => this.interestedUsersCareerGoals(careerGoal, role).length
 
   /* ################################################# COURSES HELPER FUNCTIONS ##################################### */
   private addedCourses = (): { item: ICourse, count: number }[] => {
@@ -158,6 +247,83 @@ class IndividualExplorerPage extends React.Component<IIndividualExplorerPageProp
     return course;
   }
 
+  private isCourseCompleted = (): boolean => {
+    let ret = false;
+    const courseSlugName = this.props.match.params.course;
+    const courseStatus = this.passedCourseHelper(courseSlugName);
+    if (courseStatus === 'Completed') {
+      ret = true;
+    }
+    return ret;
+  }
+
+  private passedCourseHelper = (courseSlugName: string): string => {
+    let ret = 'Not in plan';
+    const slug = Slugs.find({ name: courseSlugName }).fetch();
+    const course = Courses.find({ slugID: slug[0]._id }).fetch();
+    const ci = CourseInstances.find({
+      studentID: Router.getUserIdFromRoute(this.props.match),
+      courseID: course[0]._id,
+    })
+      .fetch();
+    _.forEach(ci, (c) => {
+      if (c.verified === true) {
+        ret = 'Completed';
+      } else if (ret !== 'Completed') {
+        ret = 'In plan, but not yet complete';
+      }
+    });
+    return ret;
+  }
+
+  private descriptionPairsCourses = (course: ICourse): object[] => [
+    { label: 'Course Number', value: course.num },
+    { label: 'Credit Hours', value: course.creditHrs },
+    { label: 'Description', value: course.description },
+    { label: 'Syllabus', value: course.syllabus },
+    { label: 'Interests', value: _.sortBy(Interests.findNames(course.interestIDs)) },
+    { label: 'Prerequisites', value: this.prerequisites(course) },
+  ]
+
+  private prerequisites = (course: ICourse): any[] => {
+    const list = course.prerequisites;
+    const complete = [];
+    const incomplete = [];
+    const notInPlan = [];
+    let itemStatus = '';
+    _.forEach(list, (item) => {
+      itemStatus = this.prerequisiteStatus(item);
+      if (itemStatus === 'Not in plan') {
+        notInPlan.push({ course: item, status: itemStatus });
+      } else if (itemStatus === 'Completed') {
+        complete.push({ course: item, status: itemStatus });
+      } else {
+        incomplete.push({ course: item, status: itemStatus });
+      }
+    });
+    if (complete.length === 0 && incomplete.length === 0 && notInPlan.length === 0) {
+      return null;
+    }
+    return [complete, incomplete, notInPlan];
+  }
+
+  private prerequisiteStatus = (prerequisite: string) => {
+    if (isSingleChoice(prerequisite)) {
+      return this.passedCourseHelper(prerequisite);
+    }
+    const slugs = prerequisite.split(',');
+    let ret = 'Not in plan';
+    slugs.forEach((slug) => {
+      const result = this.passedCourseHelper(slug);
+      if (result === 'Completed') {
+        ret = result;
+      } else if (result === 'In plan, but not yet complete') {
+        ret = result;
+      }
+    });
+    return ret;
+  }
+
   /* ################################################# DEGREES HELPER FUNCTIONS ##################################### */
   private addedDegrees = (): { item: IDesiredDegree, count: number }[] => _.map(DesiredDegrees.findNonRetired({}, { sort: { name: 1 } }), (d) => ({
     item: d,
@@ -170,6 +336,11 @@ class IndividualExplorerPage extends React.Component<IIndividualExplorerPageProp
     const degree = DesiredDegrees.findNonRetired({ slugID: slug[0]._id });
     return degree[0];
   }
+
+  private descriptionPairsDegrees = (degree: IDesiredDegree): { label: string, value: any }[] => [{
+    label: 'Description',
+    value: degree.description,
+  }]
 
   /* ################################################# INTERESTS HELPER FUNCTIONS ################################### */
   private addedInterests = (): { item: IInterest, count: number }[] => {
@@ -232,11 +403,55 @@ class IndividualExplorerPage extends React.Component<IIndividualExplorerPageProp
     return opportunity[0];
   }
 
+  private isOpportunityCompleted = (): boolean => {
+    const opportunitySlugName = this.props.match.params.opportunity;
+    let ret = false;
+    const slug = Slugs.find({ name: opportunitySlugName }).fetch();
+    const opportunity = Opportunities.find({ slugID: slug[0]._id }).fetch();
+    const oi = OpportunityInstances.find({
+      studentID: Router.getUserIdFromRoute(this.props.match),
+      opportunityID: opportunity[0]._id,
+      verified: true,
+    }).fetch();
+    if (oi.length > 0) {
+      ret = true;
+    }
+    return ret;
+  }
+
+  private descriptionPairsOpportunities = (opportunity: IOpportunity): { label: string, value: any }[] => [
+    { label: 'Opportunity Type', value: this.opportunityType(opportunity) },
+    { label: 'Semesters', value: this.academicTerms(opportunity) },
+    { label: 'Event Date', value: opportunity.eventDate },
+    { label: 'Sponsor', value: this.sponsor(opportunity) },
+    { label: 'Description', value: opportunity.description },
+    { label: 'Interests', value: opportunity.interestIDs },
+    { label: 'ICE', value: opportunity.ice },
+    { label: 'Teaser', value: this.teaser(opportunity) },
+  ]
+
+  private opportunityType = (opportunity: IOpportunity): string => {
+    const oppType = opportunity.opportunityTypeID;
+    const oppSlug = OpportunityTypes.findSlugByID(oppType);
+    return OpportunityTypes.findDocBySlug(oppSlug).name;
+  }
+
+  private academicTerms = (opportunity: IOpportunity): string[] => {
+    const termIDs = opportunity.termIDs;
+    return _.map(termIDs, (termID) => AcademicTerms.toString(termID));
+  }
+
+  private sponsor = (opportunity: IOpportunity): string => Users.getFullName(opportunity.sponsorID);
+
+  private teaser = (opportunity: IOpportunity): object => {
+    const oppTeaser = Teasers.find({ opportunityID: opportunity._id }).fetch();
+    return oppTeaser[0];
+  }
+
   public render(): React.ReactElement<any> | string | number | {} | React.ReactNodeArray | React.ReactPortal | boolean | null | undefined {
-    const { match } = this.props;
-    const menuWidget = Router.renderPageMenuWidget(match);
-    const type = Router.getIndividualExplorerType(match);
-    const role = Router.getRoleByUrl(match);
+    const menuWidget = this.getMenuWidget();
+    const type = this.getType();
+    const role = this.getRole();
 
     // Variables for Explorer Menu
     const addedList = this.getAddedList();
@@ -244,7 +459,7 @@ class IndividualExplorerPage extends React.Component<IIndividualExplorerPageProp
     // Variables for Individual Explorer Widgets
     const item = this.getItem();
     const name = item.name;
-    const descriptionPairs = this.getDescriptionPairs();
+    const descriptionPairs = this.getDescriptionPairs(item);
 
     // Variables to deal with individual props unique to a certain epxlorer type
     /* Explorer Interests Widget */
@@ -253,13 +468,13 @@ class IndividualExplorerPage extends React.Component<IIndividualExplorerPageProp
     /* Explorer Courses Widget */
     const isTypeCourses = type === EXPLORER_TYPE.COURSES;
     const shortName = isTypeCourses ? item.shortName : undefined;
-    const isCourseCompleted = isTypeCourses ? this.completedCourse() : undefined;
+    const isCourseCompleted = isTypeCourses ? this.isCourseCompleted() : undefined;
     /* Explorer Career Goals Widget */
     const isTypeCareerGoals = type === EXPLORER_TYPE.CAREERGOAL;
-    const socialPairs = isTypeCareerGoals ? this.socialPairsCareerGoals() : undefined;
+    const socialPairs = isTypeCareerGoals ? this.socialPairsCareerGoals(item as ICareerGoal) : undefined;
     /* Explorer Opportunities Widget */
     const isTypeOpportunities = type === EXPLORER_TYPE.OPPORTUNITIES;
-    const isOpportunityCompleted = isTypeOpportunities ? this.completedOpportunity() : undefined;
+    const isOpportunityCompleted = isTypeOpportunities ? this.isOpportunityCompleted() : undefined;
 
     return (
       <React.Fragment>
@@ -319,4 +534,7 @@ class IndividualExplorerPage extends React.Component<IIndividualExplorerPageProp
   }
 }
 
-export default IndividualExplorerPage;
+const IndividualExplorerPageCon = withGlobalSubscription(IndividualExplorerPage);
+const IndividualExplorerPageContainer = withInstanceSubscriptions(IndividualExplorerPageCon);
+
+export default IndividualExplorerPageContainer;

--- a/app/imports/ui/pages/shared/IndividualExplorerPage.tsx
+++ b/app/imports/ui/pages/shared/IndividualExplorerPage.tsx
@@ -1,0 +1,322 @@
+import * as React from 'react';
+import { Grid } from 'semantic-ui-react';
+import * as _ from 'lodash';
+import * as Router from '../../components/shared/RouterHelperFunctions';
+import HelpPanelWidgetContainer from '../../components/shared/HelpPanelWidget';
+import ExplorerMenu from '../../components/shared/ExplorerMenu';
+import { EXPLORER_TYPE } from '../../components/shared/ExplorerConstants';
+import { IAcademicPlan, ICareerGoal, ICourse, IDesiredDegree, IInterest, IOpportunity } from '../../../typings/radgrad'; // eslint-disable-line
+import { Users } from '../../../api/user/UserCollection';
+import { Interests } from '../../../api/interest/InterestCollection';
+import { AcademicPlans } from '../../../api/degree-plan/AcademicPlanCollection';
+import { Courses } from '../../../api/course/CourseCollection';
+import { CourseInstances } from '../../../api/course/CourseInstanceCollection';
+import { DesiredDegrees } from '../../../api/degree-plan/DesiredDegreeCollection';
+import { Opportunities } from '../../../api/opportunity/OpportunityCollection';
+import { OpportunityInstances } from '../../../api/opportunity/OpportunityInstanceCollection';
+import { CareerGoals } from '../../../api/career/CareerGoalCollection';
+import ExplorerPlansWidget from '../../components/shared/ExplorerPlansWidget';
+import ExplorerOpportunitiesWidget from '../../components/shared/ExplorerOpportunitiesWidget';
+import ExplorerDegreesWidget from '../../components/shared/ExplorerDegreesWidget';
+import ExplorerCoursesWidget from '../../components/shared/ExplorerCoursesWidget';
+import ExplorerInterestsWidget from '../../components/shared/ExplorerInterestsWidget';
+import { Slugs } from '../../../api/slug/SlugCollection';
+
+interface IIndividualExplorerPageProps {
+  match: {
+    isExact: boolean;
+    path: string;
+    url: string;
+    params: {
+      username: string;
+      course?: string;
+      degree?: string;
+      opportunity?: string;
+      plan?: string;
+      interest?: string;
+      careergoal?: string;
+    }
+  };
+}
+
+class IndividualExplorerPage extends React.Component<IIndividualExplorerPageProps> {
+  constructor(props) {
+    super(props);
+  }
+
+  private getType = (): string => Router.getIndividualExplorerType(this.props.match);
+
+  /* ################################################# EXPLORER MENU HELPER FUNCTIONS ############################### */
+  private getAddedList = (): { [key: string]: any }[] => {
+    const type = this.getType();
+    switch (type) {
+      case 'plans':
+        return this.addedPlans();
+      case 'career-goals':
+        return this.addedCareerGoals();
+      case 'courses':
+        return this.addedCourses();
+      case 'degrees':
+        return this.addedDegrees();
+      case 'interests':
+        return this.addedInterests();
+      case 'opportunities':
+        return this.addedOpportunities();
+      case 'users': // do nothing
+        return undefined;
+      default:
+        return undefined;
+    }
+  }
+
+  private getCareerList = (): { [key: string]: any }[] => {
+    const type = this.getType();
+    switch (type) {
+      case 'interests':
+        return this.addedCareerInterests();
+      default:
+        return undefined;
+    }
+  }
+
+  /* ################################################# WIDGET HELPER FUNCTIONS ###################################### */
+  private getItem = (): { [key: string]: any } => {
+    const type = this.getType();
+    switch (type) {
+      case 'plans':
+        return this.plan();
+      case 'career-goals':
+        return this.careerGoal();
+      case 'courses':
+        return this.course();
+      case 'degrees':
+        return this.degree();
+      case 'interests':
+        return this.interest();
+      case 'opportunities':
+        return this.opportunity();
+      case 'users': // do nothing
+        return undefined;
+      default:
+        return undefined;
+    }
+  }
+
+  /* ################################################# ACADEMIC PLAN HELPER FUNCTIONS ############################### */
+  private addedPlans = (): { item: IAcademicPlan, count: number }[] => {
+    const profile = Users.getProfile(Router.getUsername(this.props.match));
+    if (profile.academicPlanID) {
+      return [{ item: AcademicPlans.findDoc(profile.academicPlanID), count: 1 }];
+    }
+    return [];
+  }
+
+  private plan = (): IAcademicPlan => {
+    const planSlugName = this.props.match.params.plan;
+    const slug = Slugs.findDoc({ name: planSlugName });
+    return AcademicPlans.findDoc({ slugID: slug._id });
+  }
+
+  /* ################################################# CAREER GOALS HELPER FUNCTIONS ################################ */
+  private addedCareerGoals = (): { item: ICareerGoal, count: number }[] => {
+    const addedCareerGoals = [];
+    const allCareerGoals = CareerGoals.find({}, { sort: { name: 1 } }).fetch();
+    const profile = Users.getProfile(Router.getUsername(this.props.match));
+    _.forEach(allCareerGoals, (careerGoal) => {
+      if (_.includes(profile.careerGoalIDs, careerGoal._id)) {
+        addedCareerGoals.push({ item: careerGoal, count: 1 });
+      }
+    });
+    return addedCareerGoals;
+  }
+
+  /* ################################################# COURSES HELPER FUNCTIONS ##################################### */
+  private addedCourses = (): { item: ICourse, count: number }[] => {
+    const addedCourses = [];
+    const allCourses = _.filter(Courses.find({}, { sort: { shortName: 1 } })
+      .fetch(), (c) => !c.retired);
+    const userID = Router.getUserIdFromRoute(this.props.match);
+    _.forEach(allCourses, (course) => {
+      const ci = CourseInstances.find({
+        studentID: userID,
+        courseID: course._id,
+      })
+        .fetch();
+      if (ci.length > 0) {
+        if (course.shortName !== 'Non-CS Course') {
+          addedCourses.push({ item: course, count: ci.length });
+        }
+      }
+    });
+    return addedCourses;
+  }
+
+  private course = (): ICourse => {
+    const courseSlugName = this.props.match.params.course;
+    const slug = Slugs.find({ name: courseSlugName }).fetch();
+    const course = Courses.findDoc({ slugID: slug[0]._id });
+    return course;
+  }
+
+  /* ################################################# DEGREES HELPER FUNCTIONS ##################################### */
+  private addedDegrees = (): { item: IDesiredDegree, count: number }[] => _.map(DesiredDegrees.findNonRetired({}, { sort: { name: 1 } }), (d) => ({
+    item: d,
+    count: 1,
+  }))
+
+  private degree = (): IDesiredDegree => {
+    const degreeSlugName = this.props.match.params.degree;
+    const slug = Slugs.find({ name: degreeSlugName }).fetch();
+    const degree = DesiredDegrees.findNonRetired({ slugID: slug[0]._id });
+    return degree[0];
+  }
+
+  /* ################################################# INTERESTS HELPER FUNCTIONS ################################### */
+  private addedInterests = (): { item: IInterest, count: number }[] => {
+    const addedInterests = [];
+    if (Router.getUserIdFromRoute(this.props.match)) {
+      const allInterests = Interests.find({}, { sort: { name: 1 } }).fetch();
+      const profile = Users.getProfile(Router.getUserIdFromRoute(this.props.match));
+      _.forEach(allInterests, (interest) => {
+        if (_.includes(profile.interestIDs, interest._id)) {
+          addedInterests.push({ item: interest, count: 1 });
+        }
+      });
+    }
+    return addedInterests;
+  }
+
+  private addedCareerInterests = (): { item: IInterest, count: number }[] => {
+    if (Router.getUserIdFromRoute(this.props.match)) {
+      const profile = Users.getProfile(Router.getUserIdFromRoute(this.props.match));
+      const allInterests = Users.getInterestIDsByType(profile.userID);
+      return _.map(allInterests[1], (interest) => ({ item: Interests.findDoc(interest), count: 1 }));
+    }
+    return [];
+  }
+
+  private interest = (): IInterest => {
+    const interestSlugName = this.props.match.params.interest;
+    const slug = Slugs.find({ name: interestSlugName }).fetch();
+    const interest = Interests.find({ slugID: slug[0]._id }).fetch();
+    return interest[0];
+  }
+
+  /* ################################################# OPPORTUNITIES HELPER FUNCTIONS ############################### */
+  private addedOpportunities = (): { item: IOpportunity, count: number }[] => {
+    const addedOpportunities = [];
+    const allOpportunities = Opportunities.findNonRetired({}, { sort: { name: 1 } });
+    const userID = Router.getUserIdFromRoute(this.props.match);
+    const role = Router.getRoleByUrl(this.props.match);
+    if (role === 'faculty') {
+      return _.filter(allOpportunities, o => o.sponsorID === userID);
+    }
+    if (role === 'student') {
+      _.forEach(allOpportunities, (opportunity) => {
+        const oi = OpportunityInstances.find({
+          studentID: userID,
+          opportunityID: opportunity._id,
+        }).fetch();
+        if (oi.length > 0) {
+          addedOpportunities.push({ item: opportunity, count: oi.length });
+        }
+      });
+    }
+    return addedOpportunities;
+  }
+
+  private opportunity = (): IOpportunity => {
+    const opportunitySlugName = this.props.match.params.opportunity;
+    const slug = Slugs.find({ name: opportunitySlugName }).fetch();
+    const opportunity = Opportunities.find({ slugID: slug[0]._id }).fetch();
+    return opportunity[0];
+  }
+
+  public render(): React.ReactElement<any> | string | number | {} | React.ReactNodeArray | React.ReactPortal | boolean | null | undefined {
+    const { match } = this.props;
+    const menuWidget = Router.renderPageMenuWidget(match);
+    const type = Router.getIndividualExplorerType(match);
+    const role = Router.getRoleByUrl(match);
+
+    // Variables for Explorer Menu
+    const addedList = this.getAddedList();
+
+    // Variables for Individual Explorer Widgets
+    const item = this.getItem();
+    const name = item.name;
+    const descriptionPairs = this.getDescriptionPairs();
+
+    // Variables to deal with individual props unique to a certain epxlorer type
+    /* Explorer Interests Widget */
+    const isTypeInterests = type === EXPLORER_TYPE.INTERESTS;
+    const careerList = isTypeInterests ? this.getCareerList() : undefined;
+    /* Explorer Courses Widget */
+    const isTypeCourses = type === EXPLORER_TYPE.COURSES;
+    const shortName = isTypeCourses ? item.shortName : undefined;
+    const isCourseCompleted = isTypeCourses ? this.completedCourse() : undefined;
+    /* Explorer Career Goals Widget */
+    const isTypeCareerGoals = type === EXPLORER_TYPE.CAREERGOAL;
+    const socialPairs = isTypeCareerGoals ? this.socialPairsCareerGoals() : undefined;
+    /* Explorer Opportunities Widget */
+    const isTypeOpportunities = type === EXPLORER_TYPE.OPPORTUNITIES;
+    const isOpportunityCompleted = isTypeOpportunities ? this.completedOpportunity() : undefined;
+
+    return (
+      <React.Fragment>
+        {menuWidget}
+
+        <Grid container={true} stackable={true}>
+          <Grid.Row>
+            {<HelpPanelWidgetContainer/>}
+          </Grid.Row>
+
+          <Grid.Column width={3}>
+            <ExplorerMenu menuAddedList={addedList}
+                          menuCareerList={isTypeInterests && careerList ? careerList : undefined}
+                          type={type} role={role}/>
+          </Grid.Column>
+
+          <Grid.Column width={13}>
+            {
+              type === EXPLORER_TYPE.ACADEMICPLAN ?
+                <ExplorerPlansWidget name={name} descriptionPairs={descriptionPairs} item={item} role={role}/>
+                : ''
+            }
+            {
+              type === EXPLORER_TYPE.CAREERGOAL ?
+                <ExplorerCareerGoalsWidget name={name} descriptionPairs={descriptionPairs} item={item}
+                                           socialPairs={isTypeCareerGoals && socialPairs ? socialPairs : undefined}/>
+                : ''
+            }
+            {
+              type === EXPLORER_TYPE.COURSES ?
+                <ExplorerCoursesWidget name={name} shortName={isTypeCourses && shortName ? shortName : undefined}
+                                       descriptionPairs={descriptionPairs} item={item} role={role}
+                                       completed={(isTypeCourses && isCourseCompleted !== undefined) ? isCourseCompleted : undefined}/>
+                : ''
+            }
+            {
+              type === EXPLORER_TYPE.DEGREES ?
+                <ExplorerDegreesWidget name={name} descriptionPairs={descriptionPairs}/>
+                : ''
+            }
+            {
+              type === EXPLORER_TYPE.INTERESTS ?
+                <ExplorerInterestsWidget/>
+                : ''
+            }
+            {
+              type === EXPLORER_TYPE.OPPORTUNITIES ?
+                <ExplorerOpportunitiesWidget name={name} desriptionPairs={descriptionPairs} item={item}
+                                             completed={(isTypeOpportunities && isOpportunityCompleted !== undefined) ? isOpportunityCompleted : undefined}
+                                             role={role}/>
+                : ''
+            }
+          </Grid.Column>
+        </Grid>
+      </React.Fragment>
+    );
+  }
+}
+
+export default IndividualExplorerPage;

--- a/app/imports/ui/pages/shared/IndividualExplorerPage.tsx
+++ b/app/imports/ui/pages/shared/IndividualExplorerPage.tsx
@@ -20,7 +20,6 @@ import ExplorerOpportunitiesWidget from '../../components/shared/ExplorerOpportu
 import ExplorerDegreesWidget from '../../components/shared/ExplorerDegreesWidget';
 import ExplorerCoursesWidget from '../../components/shared/ExplorerCoursesWidget';
 import ExplorerInterestsWidget from '../../components/shared/ExplorerInterestsWidget';
-import ExplorerCareerGoalsWidget from '../../components/shared/ExplorerCareerGoalsWidget';
 import { Slugs } from '../../../api/slug/SlugCollection';
 import { ROLE } from '../../../api/role/Role';
 import { isSingleChoice } from '../../../api/degree-plan/PlanChoiceUtilities';
@@ -29,6 +28,7 @@ import { AcademicTerms } from '../../../api/academic-term/AcademicTermCollection
 import { Teasers } from '../../../api/teaser/TeaserCollection';
 import withGlobalSubscription from '../../layouts/shared/GlobalSubscriptionsHOC';
 import withInstanceSubscriptions from '../../layouts/shared/InstanceSubscriptionsHOC';
+import ExplorerCareerGoalsWidget from '../../components/shared/ExplorerCareerGoalsWidget';
 
 interface IIndividualExplorerPageProps {
   match: {
@@ -97,19 +97,19 @@ class IndividualExplorerPage extends React.Component<IIndividualExplorerPageProp
   private getItem = (): { [key: string]: any } => {
     const type = this.getType();
     switch (type) {
-      case 'plans':
+      case EXPLORER_TYPE.ACADEMICPLAN:
         return this.plan();
-      case 'career-goals':
+      case EXPLORER_TYPE.CAREERGOAL:
         return this.careerGoal();
-      case 'courses':
+      case EXPLORER_TYPE.COURSES:
         return this.course();
-      case 'degrees':
+      case EXPLORER_TYPE.DEGREES:
         return this.degree();
-      case 'interests':
+      case EXPLORER_TYPE.INTERESTS:
         return this.interest();
-      case 'opportunities':
+      case EXPLORER_TYPE.OPPORTUNITIES:
         return this.opportunity();
-      case 'users': // do nothing
+      case EXPLORER_TYPE.USERS: // do nothing
         return undefined;
       default:
         return undefined;
@@ -119,19 +119,19 @@ class IndividualExplorerPage extends React.Component<IIndividualExplorerPageProp
   private getDescriptionPairs = (item: { [key: string]: any }): object[] => {
     const type = this.getType();
     switch (type) {
-      case 'plans':
+      case EXPLORER_TYPE.ACADEMICPLAN:
         return this.descriptionPairsPlans(item as IAcademicPlan);
-      case 'career-goals':
+      case EXPLORER_TYPE.CAREERGOAL:
         return this.descriptionPairsCareerGoals(item as ICareerGoal);
-      case 'courses':
+      case EXPLORER_TYPE.COURSES:
         return this.descriptionPairsCourses(item as ICourse);
-      case 'degrees':
+      case EXPLORER_TYPE.DEGREES:
         return this.descriptionPairsDegrees(item as IDesiredDegree);
-      case 'interests':
+      case EXPLORER_TYPE.INTERESTS:
         return undefined; // Quinne implemented the descriptionPairs into their own components
-      case 'opportunities':
+      case EXPLORER_TYPE.OPPORTUNITIES:
         return this.descriptionPairsOpportunities(item as IOpportunity);
-      case 'users': // do nothing
+      case EXPLORER_TYPE.USERS: // do nothing
         return undefined;
       default:
         return undefined;
@@ -186,7 +186,7 @@ class IndividualExplorerPage extends React.Component<IIndividualExplorerPageProp
     { label: 'Interests', value: _.sortBy(Interests.findNames(careerGoal.interestIDs)) },
   ]
 
-  private socialPairsCareerGoals = (careerGoal: ICareerGoal): { label: string, amount: number, value: any }[] => [
+  private socialPairsCareerGoals = (careerGoal: ICareerGoal): { label: string, amount: number, value: object[] }[] => [
     {
       label: 'students', amount: this.numUsersCareerGoals(careerGoal, ROLE.STUDENT),
       value: this.interestedUsersCareerGoals(careerGoal, ROLE.STUDENT),
@@ -217,6 +217,7 @@ class IndividualExplorerPage extends React.Component<IIndividualExplorerPageProp
     });
     return interested;
   }
+
   private numUsersCareerGoals = (careerGoal: ICareerGoal, role: string): number => this.interestedUsersCareerGoals(careerGoal, role).length
 
   /* ################################################# COURSES HELPER FUNCTIONS ##################################### */
@@ -522,7 +523,7 @@ class IndividualExplorerPage extends React.Component<IIndividualExplorerPageProp
             }
             {
               type === EXPLORER_TYPE.OPPORTUNITIES ?
-                <ExplorerOpportunitiesWidget name={name} desriptionPairs={descriptionPairs} item={item}
+                <ExplorerOpportunitiesWidget name={name} descriptionPairs={descriptionPairs} item={item}
                                              completed={(isTypeOpportunities && isOpportunityCompleted !== undefined) ? isOpportunityCompleted : undefined}
                                              role={role}/>
                 : ''


### PR DESCRIPTION
Status: 🚧 
* *meteor npm run test* ❌ 
* *meteor npm run test-app* ❌ 

**What this accomplishes**
Similar to what #58 accomplishes. Instead of having separate page files for each of the individual explorers, everything is handled by one file. Note that this only makes the PAGE generic, not the widgets which is unlike #58 which makes the widget and page generic.

**What contributors need to know**
There are two new files that hold constants and functions that should help to prevent errors in the future and provide consistency throughout the code. First is `ExplorerConstants.ts` (ui/components/shared), which provides the string constants to the different explorer urls (i.e., /explorer/plans, where plans is the string constant).

Secondly is the much needed `RouterHelperFunctions.tsx` (ui/components/shared). This file contains many different functions that help with manipulating the **match** object that is obtained from react-router. A few of the functions implemented that will surely be used a lot is the getUsername() and getUserIdFromRoute(). Rather than having to do `this.props.match.params.username` or having to copy paste the getUserIdFromRoute() function code every time you need it, you can simply import these functions from RouterHelperFunctions.tsx.

In order to use the functions from RouterHelperFunctions, you still need to wrap your component in `withRouter` and create the typings for the match object in the interface as we have always done. Because there are many functions that you can use from this file, it is up to you whether you want to import just a single function or all the functions. If you do want to import all the functions, the conventional import should be `import * as Router from ....`. All of the functions must be passed the match object obtained from withRouter. (i.e., Router.getUserIdFromRoute(this.props.match)).