### PR TITLE
[issue-91] Ability to delete Academic Year in Student Degree Planner

### DIFF
--- a/app/imports/ui/components/student/DegreeExperiencePlannerWidget.tsx
+++ b/app/imports/ui/components/student/DegreeExperiencePlannerWidget.tsx
@@ -3,11 +3,15 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { _ } from 'meteor/erasaur:meteor-lodash';
 import { Grid, Segment, Button, Icon } from 'semantic-ui-react';
+import Swal from 'sweetalert2';
 import { selectCourseInstance, selectOpportunityInstance, selectInspectorTab } from '../../../redux/actions/actions';
 import { Users } from '../../../api/user/UserCollection';
 import { AcademicYearInstances } from '../../../api/degree-plan/AcademicYearInstanceCollection';
 import AcademicYearView from './AcademicYearView';
-import { IAcademicYear } from '../../../typings/radgrad'; // eslint-disable-line
+import { IAcademicYear, IAcademicYearDefine, ICourseInstance, IOpportunityInstance } from '../../../typings/radgrad'; // eslint-disable-line
+import { CourseInstances } from '../../../api/course/CourseInstanceCollection';
+import { OpportunityInstances } from '../../../api/opportunity/OpportunityInstanceCollection';
+import { defineMethod, removeItMethod } from '../../../api/base/BaseCollection.methods';
 
 interface IDePProps {
   selectCourseInstance: (courseInstanceID: string) => any;
@@ -23,25 +27,26 @@ interface IDePProps {
   };
 }
 
+// FIXME: Figure out a way so we dont have to do "{[key: string]: any}". This is mainly have to do with the handleDeleteYear.
+//        Can't call ._id on an AcademicYear type
 interface IDePState {
-  visibleYears: IAcademicYear[];
+  visibleYears: IAcademicYear[] | { [key: string]: any };
   visibleStartIndex: number;
-  years: IAcademicYear[];
+  years: IAcademicYear[] | { [key: string]: any };
 }
 
 const mapDispatchToProps = (dispatch) => ({
-    selectCourseInstance: (courseInstanceID) => dispatch(selectCourseInstance(courseInstanceID)),
-    selectOpportunityInstance: (opportunityInstanceID) => dispatch(selectOpportunityInstance(opportunityInstanceID)),
-    selectInspectorTab: () => dispatch(selectInspectorTab()),
-  });
+  selectCourseInstance: (courseInstanceID) => dispatch(selectCourseInstance(courseInstanceID)),
+  selectOpportunityInstance: (opportunityInstanceID) => dispatch(selectOpportunityInstance(opportunityInstanceID)),
+  selectInspectorTab: () => dispatch(selectInspectorTab()),
+});
 
 class DEPWidget extends React.Component<IDePProps, IDePState> {
-
   constructor(props) {
     super(props);
     const username = props.match.params.username;
     const studentID = Users.getID(username);
-    const years: IAcademicYear[] = AcademicYearInstances.find({ studentID }, { sort: { year: 1 } }).fetch();
+    const years = AcademicYearInstances.find({ studentID }, { sort: { year: 1 } }).fetch();
     console.log(years);
     let visibleYears;
     let visibleStartIndex = 0;
@@ -92,14 +97,67 @@ class DEPWidget extends React.Component<IDePProps, IDePState> {
     });
   }
 
-  public handleAddYear = (event) => {
+  public handleAddYear = (event: any): void => {
     event.preventDefault();
     const student = this.props.match.params.username;
     const numYears = this.state.years.length;
     const nextYear = this.state.years[numYears - 1].year + 1;
-    AcademicYearInstances.define({ year: nextYear, student });
+    const definitionData: IAcademicYearDefine = { year: nextYear, student };
+    const collectionName = AcademicYearInstances.getCollectionName();
+    defineMethod.call({ collectionName, definitionData }, (error) => {
+      if (error) {
+        Swal.fire({
+          title: 'Failed to create Academic Year',
+          text: error.message,
+          type: 'error',
+        });
+      } else {
+        Swal.fire({
+          title: 'Academic Year Created',
+          type: 'success',
+          text: 'Successfully created a new Academic Year',
+          allowOutsideClick: false,
+          allowEscapeKey: false,
+          allowEnterKey: false,
+        });
+      }
+    });
     const studentID = Users.getID(student);
-    const years: IAcademicYear[] = AcademicYearInstances.find({ studentID }, { sort: { year: 1 } }).fetch();
+    const years = AcademicYearInstances.find({ studentID }, { sort: { year: 1 } }).fetch();
+    const visibleStartIndex = this.state.visibleStartIndex - 1;
+    const visibleYears = this.state.years.slice(visibleStartIndex, visibleStartIndex + 5);
+    this.setState({
+      years,
+      visibleYears,
+    });
+  }
+
+  public handleDeleteYear = (event: any): void => {
+    event.preventDefault();
+    const collectionName = AcademicYearInstances.getCollectionName();
+    const instance = this.state.visibleYears[this.state.visibleYears.length - 1]._id;
+    removeItMethod.call({ collectionName, instance }, (error) => {
+      if (error) {
+        Swal.fire({
+          title: 'Failed to delete Academic Year',
+          text: error.message,
+          type: 'error',
+        });
+      } else {
+        Swal.fire({
+          title: 'Academic Year Deleted',
+          type: 'success',
+          text: 'Successfully deleted an empty Academic Year',
+          allowOutsideClick: false,
+          allowEscapeKey: false,
+          allowEnterKey: false,
+        });
+      }
+    });
+
+    const student = this.props.match.params.username;
+    const studentID = Users.getID(student);
+    const years = AcademicYearInstances.find({ studentID }, { sort: { year: 1 } }).fetch();
     const visibleYears = this.state.years.slice(this.state.visibleStartIndex, this.state.visibleStartIndex + 5);
     this.setState({
       years,
@@ -107,22 +165,41 @@ class DEPWidget extends React.Component<IDePProps, IDePState> {
     });
   }
 
-  public render() {
+  public isTermEmpty = (termID: string): boolean => {
     const username = this.props.match.params.username;
     const studentID = Users.getID(username);
-    // console.log(this.state.visibleYears);
+    const courseInstances = CourseInstances.findNonRetired({
+      termID: termID,
+      studentID: studentID,
+    });
+    const opportunityInstances = OpportunityInstances.findNonRetired({
+      termID: termID,
+      studentID: studentID,
+    });
+    return courseInstances.length === 0 && opportunityInstances.length === 0;
+  }
+
+  public isYearEmpty = (year: IAcademicYear): boolean => {
+    const mapped = year.termIDs.map((termID) => this.isTermEmpty(termID));
+    return mapped.every(bool => bool === true);
+  }
+
+  public render() {
+    const { visibleYears, visibleStartIndex, years } = this.state;
+    const username = this.props.match.params.username;
+    const studentID = Users.getID(username);
     return (
       <Segment padded={true}>
         <Grid stackable={true} columns="equal">
           <Grid.Row stretched={true}>
-            {_.map(this.state.visibleYears, (year) => (
+            {_.map(visibleYears, (year) => (
               <AcademicYearView key={year._id} academicYear={year} studentID={studentID}
                                 handleClickCourseInstance={this.handleClickCourseInstance}
                                 handleClickOpportunityInstance={this.handleClickOpportunityInstance}/>
             ))}
           </Grid.Row>
           <Grid.Row>
-            <Grid.Column>{this.state.visibleStartIndex > 0 ?
+            <Grid.Column>{visibleStartIndex > 0 ?
               <Button color="green" icon={true} labelPosition="left" onClick={this.handleClickPrevYear}>
                 <Icon name="arrow circle left"/>
                 Prev Year
@@ -133,11 +210,18 @@ class DEPWidget extends React.Component<IDePProps, IDePState> {
                 <Icon name="plus circle"/> Add Academic Year
               </Button>
             </Grid.Column>
-            <Grid.Column>{this.state.visibleStartIndex < this.state.years.length - 4 ?
-              <Button color="green" icon={true} labelPosition="right" onClick={this.handleClickNextYear}>
-                <Icon name="arrow circle right"/>
-                Next Year
-              </Button> : ''}
+            <Grid.Column>
+              {this.isYearEmpty(years[years.length - 1]) ?
+                <Button color="green" icon={true} labelPosition="right" onClick={this.handleDeleteYear}>
+                  <Icon name="minus circle"/> Delete Year
+                </Button>
+                :
+                (visibleStartIndex < years.length - 4 &&
+                  (<Button color="green" icon={true} labelPosition="right" onClick={this.handleClickNextYear}>
+                    <Icon name="arrow circle right"/>
+                    Next Year
+                  </Button>))
+              }
             </Grid.Column>
           </Grid.Row>
         </Grid>

--- a/app/imports/ui/components/student/DegreeExperiencePlannerWidget.tsx
+++ b/app/imports/ui/components/student/DegreeExperiencePlannerWidget.tsx
@@ -61,18 +61,17 @@ class DEPWidget extends React.Component<IDePProps, IDePState> {
       visibleStartIndex,
       visibleYears,
     };
+    console.log('initial state %o', this.state);
   }
 
   public handleClickCourseInstance = (event, { value }) => {
     event.preventDefault();
-    // console.log(`course instance id ${value}`);
     this.props.selectCourseInstance(value);
     this.props.selectInspectorTab();
   }
 
   public handleClickOpportunityInstance = (event, { value }) => {
     event.preventDefault();
-    // console.log(`opportunity instance id ${value}`);
     this.props.selectOpportunityInstance(value);
     this.props.selectInspectorTab();
   }
@@ -80,7 +79,7 @@ class DEPWidget extends React.Component<IDePProps, IDePState> {
   public handleClickPrevYear = (event) => {
     event.preventDefault();
     const visibleStartIndex = this.state.visibleStartIndex - 1;
-    const visibleYears = this.state.years.slice(visibleStartIndex, visibleStartIndex + 5);
+    const visibleYears = this.state.years.slice(visibleStartIndex, visibleStartIndex + 4);
     this.setState({
       visibleStartIndex,
       visibleYears,
@@ -90,7 +89,7 @@ class DEPWidget extends React.Component<IDePProps, IDePState> {
   public handleClickNextYear = (event) => {
     event.preventDefault();
     const visibleStartIndex = this.state.visibleStartIndex + 1;
-    const visibleYears = this.state.years.slice(visibleStartIndex, visibleStartIndex + 5);
+    const visibleYears = this.state.years.slice(visibleStartIndex, visibleStartIndex + 4);
     this.setState({
       visibleStartIndex,
       visibleYears,
@@ -124,12 +123,12 @@ class DEPWidget extends React.Component<IDePProps, IDePState> {
     });
     const studentID = Users.getID(student);
     const years = AcademicYearInstances.find({ studentID }, { sort: { year: 1 } }).fetch();
-    const visibleStartIndex = this.state.visibleStartIndex - 1;
-    const visibleYears = this.state.years.slice(visibleStartIndex, visibleStartIndex + 5);
+    const visibleYears = this.state.years.slice(this.state.visibleStartIndex, this.state.visibleStartIndex + 5);
     this.setState({
       years,
       visibleYears,
     });
+    console.log('state after adding %o', this.state);
   }
 
   public handleDeleteYear = (event: any): void => {
@@ -158,11 +157,13 @@ class DEPWidget extends React.Component<IDePProps, IDePState> {
     const student = this.props.match.params.username;
     const studentID = Users.getID(student);
     const years = AcademicYearInstances.find({ studentID }, { sort: { year: 1 } }).fetch();
-    const visibleYears = this.state.years.slice(this.state.visibleStartIndex, this.state.visibleStartIndex + 5);
+    const visibleStartIndex = this.state.visibleStartIndex - 1;
+    const visibleYears = this.state.years.slice(visibleStartIndex, visibleStartIndex + 4);
     this.setState({
       years,
       visibleYears,
     });
+    console.log('state after deletion %o', this.state);
   }
 
   public isTermEmpty = (termID: string): boolean => {
@@ -211,16 +212,17 @@ class DEPWidget extends React.Component<IDePProps, IDePState> {
               </Button>
             </Grid.Column>
             <Grid.Column>
-              {this.isYearEmpty(years[years.length - 1]) ?
-                <Button color="green" icon={true} labelPosition="right" onClick={this.handleDeleteYear}>
-                  <Icon name="minus circle"/> Delete Year
-                </Button>
-                :
-                (visibleStartIndex < years.length - 4 &&
+              {
+                visibleStartIndex < years.length - 4 ?
                   (<Button color="green" icon={true} labelPosition="right" onClick={this.handleClickNextYear}>
                     <Icon name="arrow circle right"/>
                     Next Year
-                  </Button>))
+                  </Button>)
+                  :
+                  (this.isYearEmpty(years[years.length - 1]) &&
+                    <Button color="green" icon={true} labelPosition="right" onClick={this.handleDeleteYear}>
+                      <Icon name="minus circle"/> Delete Year
+                    </Button>)
               }
             </Grid.Column>
           </Grid.Row>

--- a/app/imports/ui/components/student/DegreeExperiencePlannerWidget.tsx
+++ b/app/imports/ui/components/student/DegreeExperiencePlannerWidget.tsx
@@ -47,7 +47,6 @@ class DEPWidget extends React.Component<IDePProps, IDePState> {
     const username = props.match.params.username;
     const studentID = Users.getID(username);
     const years = AcademicYearInstances.find({ studentID }, { sort: { year: 1 } }).fetch();
-    console.log(years);
     let visibleYears;
     let visibleStartIndex = 0;
     if (years.length > 4) {
@@ -61,7 +60,6 @@ class DEPWidget extends React.Component<IDePProps, IDePState> {
       visibleStartIndex,
       visibleYears,
     };
-    console.log('initial state %o', this.state);
   }
 
   public handleClickCourseInstance = (event, { value }) => {
@@ -128,7 +126,6 @@ class DEPWidget extends React.Component<IDePProps, IDePState> {
       years,
       visibleYears,
     });
-    console.log('state after adding %o', this.state);
   }
 
   public handleDeleteYear = (event: any): void => {
@@ -139,7 +136,7 @@ class DEPWidget extends React.Component<IDePProps, IDePState> {
       if (error) {
         Swal.fire({
           title: 'Failed to delete Academic Year',
-          text: error.message,
+          text: `${error.message}. The page most likely didn't update properly fast enough. Refresh the page if you see this error.`,
           type: 'error',
         });
       } else {
@@ -163,7 +160,6 @@ class DEPWidget extends React.Component<IDePProps, IDePState> {
       years,
       visibleYears,
     });
-    console.log('state after deletion %o', this.state);
   }
 
   public isTermEmpty = (termID: string): boolean => {
@@ -199,31 +195,28 @@ class DEPWidget extends React.Component<IDePProps, IDePState> {
                                 handleClickOpportunityInstance={this.handleClickOpportunityInstance}/>
             ))}
           </Grid.Row>
-          <Grid.Row>
-            <Grid.Column>{visibleStartIndex > 0 ?
-              <Button color="green" icon={true} labelPosition="left" onClick={this.handleClickPrevYear}>
-                <Icon name="arrow circle left"/>
-                Prev Year
-              </Button> : ''}
+          <Grid.Row textAlign="center">
+            <Grid.Column textAlign="left">
+              {visibleStartIndex > 0 ?
+                <Button color="green" icon={true} labelPosition="left" onClick={this.handleClickPrevYear}>
+                  <Icon name="arrow circle left"/>Previous Year
+                </Button> : ''}
             </Grid.Column>
-            <Grid.Column>
-              <Button color="green" icon={true} labelPosition="left" onClick={this.handleAddYear}>
+            <Grid.Column textAlign="center">
+              <Button color="green" onClick={this.handleAddYear}>
                 <Icon name="plus circle"/> Add Academic Year
               </Button>
             </Grid.Column>
-            <Grid.Column>
-              {
-                visibleStartIndex < years.length - 4 ?
-                  (<Button color="green" icon={true} labelPosition="right" onClick={this.handleClickNextYear}>
-                    <Icon name="arrow circle right"/>
-                    Next Year
-                  </Button>)
-                  :
-                  (this.isYearEmpty(years[years.length - 1]) &&
-                    <Button color="green" icon={true} labelPosition="right" onClick={this.handleDeleteYear}>
-                      <Icon name="minus circle"/> Delete Year
-                    </Button>)
-              }
+            <Grid.Column textAlign="right">
+              {visibleStartIndex < years.length - 4 ?
+                (<Button color="green" icon={true} labelPosition="right" onClick={this.handleClickNextYear}>
+                  <Icon name="arrow circle right"/>Next Year
+                </Button>)
+                :
+                (this.isYearEmpty(years[years.length - 1]) &&
+                  <Button color="green" icon={true} labelPosition="right" onClick={this.handleDeleteYear}>
+                    <Icon name="minus circle"/>Delete Year
+                  </Button>)}
             </Grid.Column>
           </Grid.Row>
         </Grid>


### PR DESCRIPTION
Status: 🚧 

**What this accomplishes**
Closes #91 

**What contributors need to know**
There is some weird logic behavior where after you add a new Academic Year instance by clicking on the "Add Academic Year" button, clicking on either "Next Year" or "Previous Year" will render the Degree Planner to only have 2 or 3 year columns. However, this isn't really an issue because clicking on "Next Year" or "Previous Year" again fixes it back to normal. 