### PR TITLE
[issue-59] Increased timeout to 10000ms for LevelProcessor test suites

### DIFF
--- a/app/imports/api/level/LevelProcessor.test.ts
+++ b/app/imports/api/level/LevelProcessor.test.ts
@@ -84,7 +84,7 @@ if (Meteor.isServer) {
     });
 
     it('Betty Level 4', function levelFour() {
-      this.timeout(5000);
+      this.timeout(10000);
       removeAllEntities();
       defineTestFixtures(['minimal', 'extended.courses.interests', 'betty.student.picture', 'betty.level1',
         'betty.level2', 'opportunities', 'extended.opportunities', 'betty.level3', 'betty.level4']);
@@ -95,7 +95,7 @@ if (Meteor.isServer) {
     });
 
     it('Betty Level 5', function levelFive() {
-      this.timeout(5000);
+      this.timeout(10000);
       removeAllEntities();
       defineTestFixtures(['minimal', 'extended.courses.interests', 'betty.student.picture', 'betty.level1',
         'betty.level2', 'opportunities', 'extended.opportunities', 'betty.level3', 'betty.level5']);
@@ -106,7 +106,7 @@ if (Meteor.isServer) {
     });
 
     it('Betty Level 6', function levelSix() {
-      this.timeout(5000);
+      this.timeout(10000);
       removeAllEntities();
       defineTestFixtures(['minimal', 'extended.courses.interests', 'betty.student.picture', 'betty.level1',
         'betty.level2', 'opportunities', 'extended.opportunities', 'betty.level3', 'betty.level6']);


### PR DESCRIPTION
Status: ✅ 

**What this accomplishes**
The Betty Level 4, 5, and 6 tests for the LevelProcessor test suite were taking execution times close to the previous timeout of 5000ms to execute. So in some cases when you run `meteor npm run test`, those tests exceed the 5000ms for whatever reason. This commit fixes this by raising the timeout to 10000ms

**What contributors need to know**
If you still encounter your tests failing because the timeout exceeded, please screenshot and post in #59. 