### PR TITLE
[issue-170] Turn off specific ESLint rules

### DIFF
--- a/app/imports/ui/components/admin/AdminCollectionAccordion.tsx
+++ b/app/imports/ui/components/admin/AdminCollectionAccordion.tsx
@@ -41,10 +41,8 @@ const AdminCollectionAccordion = (props: IAdminCollectionAccordionProps) => {
           {_.map(props.descriptionPairs, (descriptionPair, index) => (
             <React.Fragment key={index}>
               <b>
-                {descriptionPair.label}
-                :
+                {descriptionPair.label}:
               </b>
-              {' '}
               {typeof descriptionPair.value === 'string' ? (
                 <Markdown
                   escapeHtml

--- a/app/imports/ui/components/admin/AdminDataModelAccordion.tsx
+++ b/app/imports/ui/components/admin/AdminDataModelAccordion.tsx
@@ -47,12 +47,7 @@ const AdminDataModelAccordion = (props: IAdminDataModelAccordionProps) => {
       <Accordion.Content active={active}>
         {_.map(props.descriptionPairs, (descriptionPair, index) => (
           <React.Fragment key={index}>
-            <b>
-              {descriptionPair.label}
-              :
-            </b>
-            {' '}
-            {typeof descriptionPair.value === 'string' ? (
+            <b>{descriptionPair.label}:</b> {typeof descriptionPair.value === 'string' ? (
               <Markdown
                 escapeHtml
                 source={descriptionPair.value}

--- a/app/imports/ui/components/admin/AdminDatabaseAccordion.tsx
+++ b/app/imports/ui/components/admin/AdminDatabaseAccordion.tsx
@@ -34,12 +34,7 @@ const AdminDatabaseAccordion = (props: IAdminDatabaseAccordionProps) => {
   return (
     <Accordion styled fluid>
       <Accordion.Title active={activeIndex === props.index} index={props.index} onClick={handleClick}>
-        <Icon name="dropdown" />
-        {props.name}
-        {' '}
-        (
-        {props.contents.length}
-        )
+        <Icon name="dropdown" /> {props.name} ({props.contents.length})
       </Accordion.Title>
       <Accordion.Content active={activeIndex === props.index}>
         {prettyPrint()}

--- a/app/imports/ui/components/admin/AdminPaginationWidget.tsx
+++ b/app/imports/ui/components/admin/AdminPaginationWidget.tsx
@@ -83,9 +83,7 @@ const AdminPaginationWidget = (props: IAdminPaginationWidgetProps) => {
       >
         <Icon
           name="fast backward"
-        />
-        {' '}
-        First
+        /> First
       </Button>
       <Button
         basic
@@ -94,11 +92,7 @@ const AdminPaginationWidget = (props: IAdminPaginationWidgetProps) => {
         onClick={handlePrevClick(props)}
         style={heightStyle}
       >
-        <Icon
-          name="step backward"
-        />
-        {' '}
-        Prev
+        <Icon name="step backward" /> Prev
       </Button>
       <Message style={messageStyle}>{label}</Message>
       <Button
@@ -108,11 +102,7 @@ const AdminPaginationWidget = (props: IAdminPaginationWidgetProps) => {
         onClick={handleNextClick(props)}
         style={heightStyle}
       >
-        <Icon
-          name="step forward"
-        />
-        {' '}
-        Next
+        <Icon name="step forward" /> Next
       </Button>
       <Button
         basic
@@ -120,11 +110,7 @@ const AdminPaginationWidget = (props: IAdminPaginationWidgetProps) => {
         onClick={handleLastClick(props)}
         style={heightStyle}
       >
-        <Icon
-          name="fast forward"
-        />
-        {' '}
-        Last
+        <Icon name="fast forward" /> Last
       </Button>
       {/* <Dropdown selection={true} options={options} className="jsNum"/> */}
       <select className="ui dropdown jsNum" style={heightStyle} value={showCount} onChange={handleCountChange(props)}>

--- a/app/imports/ui/components/admin/ListSlugCollectionWidget.tsx
+++ b/app/imports/ui/components/admin/ListSlugCollectionWidget.tsx
@@ -36,11 +36,7 @@ const ListSlugCollectionWidget = (props: IListSlugCollectionWidgetProps) => {
   return (
     <Segment padded>
       <Header dividing>
-        {props.collection.getCollectionName()}
-        {' '}
-        (
-        {count}
-        )
+        {props.collection.getCollectionName()} ({count})
       </Header>
       <Grid>
         <AdminPaginationWidget

--- a/app/imports/ui/components/advisor/AdvisorLogEntryWidget.tsx
+++ b/app/imports/ui/components/advisor/AdvisorLogEntryWidget.tsx
@@ -98,20 +98,11 @@ const AdvisorLogEntryWidget = (props: IAdvisorLogEntryWidgetProps) => {
             (ele) => (
               <Segment key={ele._id}>
                 <strong>
-                  {ele.createdOn.toDateString()}
-                  {' '}
-                  {ele.createdOn.getHours()}
+                  {ele.createdOn.toDateString()} {ele.createdOn.getHours()}
                   :
                   {formatMinuteString(ele.createdOn.getMinutes())}
                   :
-                </strong>
-                {' '}
-                {ele.text}
-                {' '}
-                <i>
-                  (
-                  {Users.getProfile(ele.advisorID).firstName}
-                  )
+                </strong> {ele.text} <i>({Users.getProfile(ele.advisorID).firstName})
                 </i>
               </Segment>
             ),

--- a/app/imports/ui/components/guidedtour/advisor/opportunities.tsx
+++ b/app/imports/ui/components/guidedtour/advisor/opportunities.tsx
@@ -15,18 +15,30 @@ const GuidedTourAdvisorOpportunities = () => (
         <div>
           <Header style={styles.h1}>Verifying participation</Header>
 
-          <p style={styles.p}>RadGrad notifies students of opportunities, and when students participate, these experiences augment their ICE (Innovation, Competency, Experience) score.  The student&apos;s ICE score provides a concrete metric of progress, and RadGrad incentivizes students to achieve 100 innovation, competency and experience points by the time they graduate.</p>
+          <p style={styles.p}>RadGrad notifies students of opportunities, and when students participate, these
+            experiences augment their ICE (Innovation, Competency, Experience) score. The student&apos;s ICE score
+            provides a concrete metric of progress, and RadGrad incentivizes students to achieve 100 innovation,
+            competency and experience points by the time they graduate.</p>
 
           <p style={styles.p}>
-            But planning to experience a hackathon by adding it to your RadGrad degree plan does not mean that you will show up on the day and participate. RadGrad requires that opportunities be
-            <strong style={styles['.guided-tour-description > p strong, .guided-tour-description ul > li strong']}>verified</strong>
-            {' '}
-            before the points associated with them are actually awarded to students.
+            But planning to experience a hackathon by adding it to your RadGrad degree plan does not mean that you will
+            show up on the day and participate. RadGrad requires that opportunities be
+            <strong
+              style={styles['.guided-tour-description > p strong, .guided-tour-description ul > li strong']}
+            > verified </strong> before the points associated with them are actually awarded to students.
           </p>
 
-          <p style={styles.p}>The verification workflow is as follows: after a student experiences an opportunity, they can click on that opportunity in their degree plan and press the &quot;Request Verification&quot; button.  That adds the student&apos;s opportunity verification request to a queue as illustrated in the attached screenshot.  Both advisors and faculty have access to the queue and can accept or decline the verification request. (Note that a request can be initially declined but later accepted if the student provides new evidence that they participated.)</p>
+          <p style={styles.p}>The verification workflow is as follows: after a student experiences an opportunity, they
+            can click on that opportunity in their degree plan and press the &quot;Request Verification&quot; button.
+            That adds the student&apos;s opportunity verification request to a queue as illustrated in the attached
+            screenshot. Both advisors and faculty have access to the queue and can accept or decline the verification
+            request. (Note that a request can be initially declined but later accepted if the student provides new
+            evidence that they participated.)</p>
 
-          <p style={styles.p}>The goal of verification is not to make it difficult for students to achieve ICE points, but to simply ensure that ICE points have meaning. Without verification, anyone can get 100 innovation and experience points by simply loading up their plan with opportunities regardless of whether they actually take part in them or not.</p>
+          <p style={styles.p}>The goal of verification is not to make it difficult for students to achieve ICE points,
+            but to simply ensure that ICE points have meaning. Without verification, anyone can get 100 innovation and
+            experience points by simply loading up their plan with opportunities regardless of whether they actually
+            take part in them or not.</p>
         </div>
       </Grid.Column>
     </Grid>

--- a/app/imports/ui/components/guidedtour/faculty/whats-next.tsx
+++ b/app/imports/ui/components/guidedtour/faculty/whats-next.tsx
@@ -20,9 +20,7 @@ const GuidedTourFacultyWhatsNext = () => {
               <Header style={styles.h1}>What&apos;s next?</Header>
               <p>
                 If you do not have a RadGrad account yet, please contact a RadGrad administrator at&nbsp;
-                <a href={mailto}>{adminEmail}</a>
-                {' '}
-                to request one.
+                <a href={mailto}>{adminEmail}</a> to request one.
               </p>
               <p>If you have a RadGrad account, then please login, update your profile if necessary, and create one or more opportunities for your research projects and/or other activities of interest.</p>
               <p>

--- a/app/imports/ui/components/guidedtour/student/opportunities.tsx
+++ b/app/imports/ui/components/guidedtour/student/opportunities.tsx
@@ -24,13 +24,7 @@ const GuidedTourStudentOpportunities = (props: IOpportunitiesProps) => (
           <p style={styles.p}>
             A well-balanced student learns from experiences inside and outside of school. RadGrad
             helps you reach beyond the classroom through
-            <strong
-              style={styles.strong}
-            >
-              {props.opportunties}
-            </strong>
-            {' '}
-            opportunities. These include:
+            <strong style={styles.strong}>{props.opportunties}</strong> opportunities. These include:
           </p>
           <List>
             <List.Item style={styles.li}>

--- a/app/imports/ui/components/shared/CardExplorerWidget.tsx
+++ b/app/imports/ui/components/shared/CardExplorerWidget.tsx
@@ -243,13 +243,8 @@ const CardExplorerWidget = (props: ICardExplorerMenuWidgetProps) => {
             {
               !buildStudentUserCard ? (
                 <React.Fragment>
-                  <span style={uppercaseTextTransformStyle}>
-                    {header.title}
-                    {' '}
-                  </span>
-                  <WidgetHeaderNumber
-                    inputValue={header.count}
-                  />
+                  <span style={uppercaseTextTransformStyle}>{header.title} </span>
+                  <WidgetHeaderNumber inputValue={header.count} />
                 </React.Fragment>
                 )
                 :
@@ -280,31 +275,31 @@ const CardExplorerWidget = (props: ICardExplorerMenuWidgetProps) => {
           !buildStudentUserCard ? (
             <Card.Group style={cardGroupStyle} itemsPerRow={2} stackable>
               {
-                buildPlanCard ?
-                  items.map((item) => <PlanCard key={item._id} item={item} type={type} canAdd={canAdd} />) : ''
-              }
+                  buildPlanCard ?
+                    items.map((item) => <PlanCard key={item._id} item={item} type={type} canAdd={canAdd} />) : ''
+                }
               {
-                buildProfileCard ?
-                  items.map((item) => <ProfileCard key={item._id} item={item} type={type} canAdd />) : ''
-              }
+                  buildProfileCard ?
+                    items.map((item) => <ProfileCard key={item._id} item={item} type={type} canAdd />) : ''
+                }
               {
-                buildTermCard ?
-                  items.map((item) => (
-                    <TermCard
-                      key={item._id}
-                      item={item}
-                      type={type}
-                      isStudent={isStudent}
-                      canAdd
-                    />
-                  ))
-                  : ''
-              }
+                  buildTermCard ?
+                    items.map((item) => (
+                      <TermCard
+                        key={item._id}
+                        item={item}
+                        type={type}
+                        isStudent={isStudent}
+                        canAdd
+                      />
+                    ))
+                    : ''
+                }
               {
-                buildExplorerCard ?
-                  items.map((item) => <ExplorerCard key={item._id} item={item} type={type} />)
-                  : ''
-              }
+                  buildExplorerCard ?
+                    items.map((item) => <ExplorerCard key={item._id} item={item} type={type} />)
+                    : ''
+                }
             </Card.Group>
             )
             :

--- a/app/imports/ui/components/shared/CompletedVerificationsWidget.tsx
+++ b/app/imports/ui/components/shared/CompletedVerificationsWidget.tsx
@@ -66,13 +66,9 @@ const CompletedVerificationsWidget = (props: ICompletedVerificationsWidgetProps)
           </Grid.Row>
           <Grid.Row columns={2} style={{ paddingTop: '0px', paddingBottom: '0px' }}>
             <Grid.Column>
-              Student:
-              {' '}
-              {getStudentFullName(ele)}
+              Student: {getStudentFullName(ele)}
               <br />
-              Sponsor:
-              {' '}
-              {getSponsorFullName(ele)}
+              Sponsor: {getSponsorFullName(ele)}
               <br />
               <Grid.Row style={{ paddingTop: '14px', paddingBottom: '14px' }}>
                 <Button
@@ -82,12 +78,12 @@ const CompletedVerificationsWidget = (props: ICompletedVerificationsWidgetProps)
                   content="REOPEN"
                   attached="right"
                   label={{
-                        size: 'mini',
-                        basic: false,
-                        color: getStatusColor(ele.status),
-                        pointing: 'right',
-                        content: ele.status,
-                      }}
+                    size: 'mini',
+                    basic: false,
+                    color: getStatusColor(ele.status),
+                    pointing: 'right',
+                    content: ele.status,
+                  }}
                   labelPosition="left"
                   icon="edit outline"
                   index={i}
@@ -102,25 +98,14 @@ const CompletedVerificationsWidget = (props: ICompletedVerificationsWidgetProps)
               <br />
               {ele.processed.map((elem: IProcessed) => (
                 <React.Fragment key={elem.verifier}>
-                  Processed:
-                  {' '}
-                  {moment(elem.date).calendar()}
-                  {' '}
-                  by
-                  {' '}
-                  {elem.verifier}
-                  {' '}
-                  (
-                  {elem.status}
-                  {elem.feedback ? `, ${elem.feedback}` : ''}
-                  )
+                  Processed: {moment(elem.date).calendar()} by {elem.verifier} ({elem.status}{elem.feedback ? `, ${elem.feedback}` : ''})
                   <br />
                 </React.Fragment>
-))}
+              ))}
             </Grid.Column>
           </Grid.Row>
         </Grid>
-))}
+      ))}
       {props.completedVerifications.length < 1 && <i>No completed verifications in database.</i>}
     </Container>
   </Segment>

--- a/app/imports/ui/components/shared/ExplorerCareerGoalsWidget.tsx
+++ b/app/imports/ui/components/shared/ExplorerCareerGoalsWidget.tsx
@@ -185,9 +185,7 @@ const ExplorerCareerGoalsWidget = (props: IExplorerCareerGoalsWidgetProps) => {
             {socialPairs.map((socialPair) => (
               <Grid.Column key={toId(socialPair)} textAlign="center" style={centerAlignedColumnStyle}>
                 <h5>
-                  {toUpper(socialPair.label)}
-                  {' '}
-                  <WidgetHeaderNumber inputValue={socialPair.amount} />
+                  {toUpper(socialPair.label)} <WidgetHeaderNumber inputValue={socialPair.amount} />
                 </h5>
 
                 <Image.Group size="mini" style={imageGroupStyle}>

--- a/app/imports/ui/components/shared/ExplorerCoursesWidget.tsx
+++ b/app/imports/ui/components/shared/ExplorerCoursesWidget.tsx
@@ -53,14 +53,14 @@ const getTableTitle = (tableIndex: number, table: object[]): JSX.Element | Strin
             <i className="green checkmark icon" />
             Completed
           </h4>
-);
+        );
       }
       return (
         <h4 style={greyColorStyle}>
           <i className="grey checkmark icon" />
           Completed
         </h4>
-);
+      );
     case 1:
       if (table.length !== 0) {
         return (
@@ -68,14 +68,14 @@ const getTableTitle = (tableIndex: number, table: object[]): JSX.Element | Strin
             <i className="yellow warning sign icon" />
             In Plan (Not Yet Completed)
           </h4>
-);
+        );
       }
       return (
         <h4 style={greyColorStyle}>
           <i className="grey warning sign icon" />
           In Plan (Not Yet Completed)
         </h4>
-);
+      );
     case 2:
       if (table.length !== 0) {
         return (
@@ -83,14 +83,14 @@ const getTableTitle = (tableIndex: number, table: object[]): JSX.Element | Strin
             <i className="red warning circle icon" />
             Not in Plan
           </h4>
-);
+        );
       }
       return (
         <h4 style={greyColorStyle}>
           <i className="grey warning circle icon" />
           Not in Plan
         </h4>
-);
+      );
     default:
       return 'ERROR: More than one table.';
   }
@@ -151,11 +151,7 @@ const ExplorerCoursesWidget = (props: IExplorerCoursesWidgetProps) => {
         <Segment padded className="container">
           <Segment clearing basic style={clearingBasicSegmentStyle}>
             <Header as="h4" floated="left">
-              {upperShortName}
-              {' '}
-              (
-              {name}
-              )
+              {upperShortName} ({name})
             </Header>
             <FavoritesButton
               item={props.item}
@@ -181,24 +177,24 @@ const ExplorerCoursesWidget = (props: IExplorerCoursesWidgetProps) => {
                                 :
                               </b>
                               {
-                                descriptionPair.value ? (
-                                  <React.Fragment>
-                                    {' '}
-                                    {descriptionPair.value}
-                                    {' '}
-                                    <br />
-                                  </React.Fragment>
-                                )
-                                  : (
+                                  descriptionPair.value ? (
                                     <React.Fragment>
                                       {' '}
-                                      N/A
+                                      {descriptionPair.value}
+                                      {' '}
                                       <br />
                                     </React.Fragment>
-                                )
-}
+                                    )
+                                    : (
+                                      <React.Fragment>
+                                        {' '}
+                                        N/A
+                                        <br />
+                                      </React.Fragment>
+                                    )
+                                }
                             </React.Fragment>
-                          )
+                            )
                             : ''
                         }
                         {
@@ -209,24 +205,21 @@ const ExplorerCoursesWidget = (props: IExplorerCoursesWidgetProps) => {
                                 :
                               </b>
                               {
-                                descriptionPair.value ? (
-                                  <React.Fragment>
-                                    {' '}
-                                    {descriptionPair.value}
-                                    {' '}
-                                    <br />
-                                  </React.Fragment>
-                                )
-                                  : (
+                                  descriptionPair.value ? (
                                     <React.Fragment>
-                                      {' '}
-                                      N/A
+                                      {descriptionPair.value}
                                       <br />
                                     </React.Fragment>
-                                )
-}
+                                    )
+                                    : (
+                                      <React.Fragment>
+                                        N/A
+                                        <br />
+                                      </React.Fragment>
+                                    )
+                                }
                             </React.Fragment>
-                          )
+                            )
                             : ''
                         }
                         {
@@ -237,134 +230,133 @@ const ExplorerCoursesWidget = (props: IExplorerCoursesWidgetProps) => {
                                 :
                               </b>
                               {
-                                descriptionPair.value ? (
-                                  <Markdown
-                                    escapeHtml
-                                    source={toValueString(descriptionPair)}
-                                    renderers={{ link: (localProps) => Router.renderLink(localProps, match) }}
-                                  />
-                                )
-                                  : (
-                                    <React.Fragment>
-                                      {' '}
-                                      N/A
-                                      <br />
-                                    </React.Fragment>
-                                )
-}
+                                  descriptionPair.value ? (
+                                    <Markdown
+                                      escapeHtml
+                                      source={toValueString(descriptionPair)}
+                                      renderers={{ link: (localProps) => Router.renderLink(localProps, match) }}
+                                    />
+                                    )
+                                    : (
+                                      <React.Fragment>
+                                        N/A
+                                        <br />
+                                      </React.Fragment>
+                                    )
+                                }
                             </React.Fragment>
-                          )
+                            )
                             : ''
                         }
                         {
                           isSame(descriptionPair.label, 'Prerequisites') ? (
                             <React.Fragment>
                               {
-                                descriptionPair.value ? (
-                                  <React.Fragment>
-                                    <Header as="h4" className="horizontal divider">{descriptionPair.label}</Header>
-                                    {
-                                      isStudent ? (
-                                        <Grid columns={3} stackable padded celled>
-                                          <Grid.Row>
-                                            {
-                                              toValueArray(descriptionPair).map((table, tableIndex) => (
-                                                <Grid.Column
-                                                  key={_.uniqueId()}
-                                                  style={{
-                                                  textAlign: 'center',
-                                                  backgroundColor: color(table),
-                                                }}
-                                                >
-                                                  {getTableTitle(tableIndex, table)}
-                                                  {
-                                                    length(table) ? (
-                                                      <React.Fragment>
+                                  descriptionPair.value ? (
+                                    <React.Fragment>
+                                      <Header as="h4" className="horizontal divider">{descriptionPair.label}</Header>
+                                      {
+                                          isStudent ? (
+                                            <Grid columns={3} stackable padded celled>
+                                              <Grid.Row>
+                                                {
+                                                    toValueArray(descriptionPair).map((table, tableIndex) => (
+                                                      <Grid.Column
+                                                        key={_.uniqueId()}
+                                                        style={{
+                                                          textAlign: 'center',
+                                                          backgroundColor: color(table),
+                                                        }}
+                                                      >
+                                                        {getTableTitle(tableIndex, table)}
                                                         {
-                                                          table.map((prerequisite) => (
-                                                            <React.Fragment key={_.uniqueId()}>
+                                                          length(table) ? (
+                                                            <React.Fragment>
                                                               {
-                                                                isSingleChoice(prerequisite.course) ? (
-                                                                  <NavLink
-                                                                    exact
-                                                                    to={Router.buildRouteName(props.match, `/${EXPLORER_TYPE.HOME}/${EXPLORER_TYPE.COURSES}/${prerequisite.course}`)}
-                                                                    activeClassName="active item"
-                                                                  >
-                                                                    {courseSlugToName(prerequisite.course)}
-                                                                    <br />
-                                                                  </NavLink>
-                                                                )
-                                                                  :
-                                                                  _.map(choices(prerequisite), (choice, choicesIndex) => (
+                                                                  table.map((prerequisite) => (
                                                                     <React.Fragment key={_.uniqueId()}>
                                                                       {
-                                                                        isFirst(choicesIndex) ? (
+                                                                        isSingleChoice(prerequisite.course) ? (
                                                                           <NavLink
                                                                             exact
-                                                                            to={Router.buildRouteName(props.match, `/${EXPLORER_TYPE.HOME}/${EXPLORER_TYPE.COURSES}/${choice}`)}
+                                                                            to={Router.buildRouteName(props.match, `/${EXPLORER_TYPE.HOME}/${EXPLORER_TYPE.COURSES}/${prerequisite.course}`)}
                                                                             activeClassName="active item"
                                                                           >
-                                                                            {courseSlugToName(choice)}
+                                                                            {courseSlugToName(prerequisite.course)}
+                                                                            <br />
                                                                           </NavLink>
-                                                                        )
-                                                                          : (
-                                                                            <React.Fragment>
-                                                                              {/* Not exactly sure where this pops up because even in
+                                                                          )
+                                                                          :
+                                                                          _.map(choices(prerequisite), (choice, choicesIndex) => (
+                                                                            <React.Fragment key={_.uniqueId()}>
+                                                                              {
+                                                                                isFirst(choicesIndex) ? (
+                                                                                  <NavLink
+                                                                                    exact
+                                                                                    to={Router.buildRouteName(props.match, `/${EXPLORER_TYPE.HOME}/${EXPLORER_TYPE.COURSES}/${choice}`)}
+                                                                                    activeClassName="active item"
+                                                                                  >
+                                                                                    {courseSlugToName(choice)}
+                                                                                  </NavLink>
+                                                                                  )
+                                                                                  : (
+                                                                                    <React.Fragment>
+                                                                                      {/* Not exactly sure where this pops up because even in
                                                                              the original RadGrad I don't see any "or {choice} */}
-                                                                              or
-                                                                              {' '}
-                                                                              <NavLink
-                                                                                exact
-                                                                                to={Router.buildRouteName(props.match, `/${EXPLORER_TYPE.HOME}/${EXPLORER_TYPE.COURSES}/${choice}`)}
-                                                                                activeClassName="active item"
-                                                                              >
-                                                                                {courseSlugToName(choice)}
-                                                                              </NavLink>
+                                                                                      or
+                                                                                      {' '}
+                                                                                      <NavLink
+                                                                                        exact
+                                                                                        to={Router.buildRouteName(props.match, `/${EXPLORER_TYPE.HOME}/${EXPLORER_TYPE.COURSES}/${choice}`)}
+                                                                                        activeClassName="active item"
+                                                                                      >
+                                                                                        {courseSlugToName(choice)}
+                                                                                      </NavLink>
+                                                                                    </React.Fragment>
+                                                                                  )
+                                                                              }
                                                                             </React.Fragment>
-                                                                        )
-}
+                                                                          ))
+                                                                      }
                                                                     </React.Fragment>
                                                                   ))
-                                                              }
+                                                                }
                                                             </React.Fragment>
-                                                          ))
+                                                            )
+                                                            :
+                                                            <Item style={{ color: 'grey' }}>None</Item>
                                                         }
-                                                      </React.Fragment>
-                                                    )
-                                                      :
-                                                      <Item style={{ color: 'grey' }}>None</Item>
+                                                      </Grid.Column>
+                                                    ))
                                                   }
-                                                </Grid.Column>
-                                              ))
-                                            }
-                                          </Grid.Row>
-                                        </Grid>
-                                      )
-                                        : (
-                                          <List horizontal bulleted>
-                                            {
-                                            toValueArray(descriptionPair).map((prereqType) => (
-                                              prereqType.map((prereq) => (
-                                                <List.Item
-                                                  key={prereq.course}
-                                                  as={NavLink}
-                                                  exact
-                                                  to={Router.buildRouteName(props.match, `/${EXPLORER_TYPE.HOME}/${EXPLORER_TYPE.COURSES}/${prereq.course}`)}
-                                                >
-                                                  {courseSlugToName(prereq.course)}
-                                                </List.Item>
-                                              ))
-                                            ))
-                                          }
-                                          </List>
-                                      )
-}
-                                  </React.Fragment>
-                                )
-                                  : ''
-                              }
+                                              </Grid.Row>
+                                            </Grid>
+                                            )
+                                            : (
+                                              <List horizontal bulleted>
+                                                {
+                                                  toValueArray(descriptionPair).map((prereqType) => (
+                                                    prereqType.map((prereq) => (
+                                                      <List.Item
+                                                        key={prereq.course}
+                                                        as={NavLink}
+                                                        exact
+                                                        to={Router.buildRouteName(props.match, `/${EXPLORER_TYPE.HOME}/${EXPLORER_TYPE.COURSES}/${prereq.course}`)}
+                                                      >
+                                                        {courseSlugToName(prereq.course)}
+                                                      </List.Item>
+                                                    ))
+                                                  ))
+                                                }
+                                              </List>
+                                            )
+                                        }
+                                    </React.Fragment>
+                                    )
+                                    : ''
+                                }
                             </React.Fragment>
-                          )
+                            )
                             : ''
                         }
                       </React.Fragment>
@@ -383,25 +375,25 @@ const ExplorerCoursesWidget = (props: IExplorerCoursesWidgetProps) => {
                                 :
                               </b>
                               {
-                                descriptionPair.value ? (
-                                  <div style={breakWordStyle}>
-                                    <Markdown
-                                      source={toValueString(descriptionPair)}
-                                      renderers={{ link: (localProps) => Router.renderLink(localProps, match) }}
-                                    />
-                                    <br />
-                                  </div>
-                                )
-                                  : (
-                                    <React.Fragment>
-                                      {' '}
-                                      N/A
+                                  descriptionPair.value ? (
+                                    <div style={breakWordStyle}>
+                                      <Markdown
+                                        source={toValueString(descriptionPair)}
+                                        renderers={{ link: (localProps) => Router.renderLink(localProps, match) }}
+                                      />
                                       <br />
-                                    </React.Fragment>
-                                )
-}
+                                    </div>
+                                    )
+                                    : (
+                                      <React.Fragment>
+                                        {' '}
+                                        N/A
+                                        <br />
+                                      </React.Fragment>
+                                    )
+                                }
                             </React.Fragment>
-                          )
+                            )
                             : ''
                         }
                         {
@@ -412,19 +404,19 @@ const ExplorerCoursesWidget = (props: IExplorerCoursesWidgetProps) => {
                                 :
                               </b>
                               {
-                                descriptionPair.value ? (
-                                  <Embed
-                                    active
-                                    autoplay={false}
-                                    source="youtube"
-                                    id={teaserUrlHelper(props)}
-                                  />
-                                )
-                                  :
-                                  <p> N/A </p>
-                              }
+                                  descriptionPair.value ? (
+                                    <Embed
+                                      active
+                                      autoplay={false}
+                                      source="youtube"
+                                      id={teaserUrlHelper(props)}
+                                    />
+                                    )
+                                    :
+                                    <p> N/A </p>
+                                }
                             </React.Fragment>
-                          )
+                            )
                             : ''
                         }
                       </React.Fragment>
@@ -447,24 +439,24 @@ const ExplorerCoursesWidget = (props: IExplorerCoursesWidgetProps) => {
                                   :
                                 </b>
                                 {
-                                  descriptionPair.value ? (
-                                    <React.Fragment>
-                                      {' '}
-                                      {descriptionPair.value}
-                                      {' '}
-                                      <br />
-                                    </React.Fragment>
-                                  )
-                                    : (
+                                    descriptionPair.value ? (
                                       <React.Fragment>
                                         {' '}
-                                        N/A
+                                        {descriptionPair.value}
+                                        {' '}
                                         <br />
                                       </React.Fragment>
-                                  )
-}
+                                      )
+                                      : (
+                                        <React.Fragment>
+                                          {' '}
+                                          N/A
+                                          <br />
+                                        </React.Fragment>
+                                      )
+                                  }
                               </React.Fragment>
-                            )
+                              )
                               : ''
                           }
 
@@ -476,24 +468,24 @@ const ExplorerCoursesWidget = (props: IExplorerCoursesWidgetProps) => {
                                   :
                                 </b>
                                 {
-                                  descriptionPair.value ? (
-                                    <React.Fragment>
-                                      {' '}
-                                      {descriptionPair.value}
-                                      {' '}
-                                      <br />
-                                    </React.Fragment>
-                                  )
-                                    : (
+                                    descriptionPair.value ? (
                                       <React.Fragment>
                                         {' '}
-                                        N/A
+                                        {descriptionPair.value}
+                                        {' '}
                                         <br />
                                       </React.Fragment>
-                                  )
-}
+                                      )
+                                      : (
+                                        <React.Fragment>
+                                          {' '}
+                                          N/A
+                                          <br />
+                                        </React.Fragment>
+                                      )
+                                  }
                               </React.Fragment>
-                            )
+                              )
                               : ''
                           }
                         </React.Fragment>
@@ -513,25 +505,25 @@ const ExplorerCoursesWidget = (props: IExplorerCoursesWidgetProps) => {
                                   :
                                 </b>
                                 {
-                                  descriptionPair.value ? (
-                                    <div style={breakWordStyle}>
-                                      <Markdown
-                                        source={toValueString(descriptionPair)}
-                                        renderers={{ link: (localProps) => Router.renderLink(localProps, match) }}
-                                      />
-                                      <br />
-                                    </div>
-                                  )
-                                    : (
-                                      <React.Fragment>
-                                        {' '}
-                                        N/A
+                                    descriptionPair.value ? (
+                                      <div style={breakWordStyle}>
+                                        <Markdown
+                                          source={toValueString(descriptionPair)}
+                                          renderers={{ link: (localProps) => Router.renderLink(localProps, match) }}
+                                        />
                                         <br />
-                                      </React.Fragment>
-                                  )
-}
+                                      </div>
+                                      )
+                                      : (
+                                        <React.Fragment>
+                                          {' '}
+                                          N/A
+                                          <br />
+                                        </React.Fragment>
+                                      )
+                                  }
                               </React.Fragment>
-                            )
+                              )
                               : ''
                           }
                         </React.Fragment>
@@ -552,23 +544,23 @@ const ExplorerCoursesWidget = (props: IExplorerCoursesWidgetProps) => {
                                   :
                                 </b>
                                 {
-                                  descriptionPair.value ? (
-                                    <Markdown
-                                      escapeHtml
-                                      source={toValueString(descriptionPair)}
-                                      renderers={{ link: (localProps) => Router.renderLink(localProps, match) }}
-                                    />
-                                  )
-                                    : (
-                                      <React.Fragment>
-                                        {' '}
-                                        N/A
-                                        <br />
-                                      </React.Fragment>
-                                  )
-}
+                                    descriptionPair.value ? (
+                                      <Markdown
+                                        escapeHtml
+                                        source={toValueString(descriptionPair)}
+                                        renderers={{ link: (localProps) => Router.renderLink(localProps, match) }}
+                                      />
+                                      )
+                                      : (
+                                        <React.Fragment>
+                                          {' '}
+                                          N/A
+                                          <br />
+                                        </React.Fragment>
+                                      )
+                                  }
                               </React.Fragment>
-                            )
+                              )
                               : ''
                           }
                         </React.Fragment>
@@ -585,111 +577,110 @@ const ExplorerCoursesWidget = (props: IExplorerCoursesWidgetProps) => {
                             isSame(descriptionPair.label, 'Prerequisites') ? (
                               <React.Fragment>
                                 {
-                                  descriptionPair.value ? (
-                                    <React.Fragment>
-                                      <Header as="h4" className="horizontal divider">{descriptionPair.label}</Header>
-                                      {
-                                        isStudent ? (
-                                          <Grid columns={3} stackable padded celled>
-                                            <Grid.Row>
-                                              {
-                                                toValueArray(descriptionPair).map((table, tableIndex) => (
-                                                  <Grid.Column
-                                                    key={_.uniqueId()}
-                                                    style={{
-                                                    textAlign: 'center',
-                                                    backgroundColor: color(table),
-                                                  }}
-                                                  >
-                                                    {getTableTitle(tableIndex, table)}
-                                                    {
-                                                      length(table) ? (
-                                                        <React.Fragment>
+                                    descriptionPair.value ? (
+                                      <React.Fragment>
+                                        <Header as="h4" className="horizontal divider">{descriptionPair.label}</Header>
+                                        {
+                                            isStudent ? (
+                                              <Grid columns={3} stackable padded celled>
+                                                <Grid.Row>
+                                                  {
+                                                      toValueArray(descriptionPair).map((table, tableIndex) => (
+                                                        <Grid.Column
+                                                          key={_.uniqueId()}
+                                                          style={{
+                                                            textAlign: 'center',
+                                                            backgroundColor: color(table),
+                                                          }}
+                                                        >
+                                                          {getTableTitle(tableIndex, table)}
                                                           {
-                                                            table.map((prerequisite) => (
-                                                              <React.Fragment key={_.uniqueId()}>
+                                                            length(table) ? (
+                                                              <React.Fragment>
                                                                 {
-                                                                  isSingleChoice(prerequisite.course) ? (
-                                                                    <NavLink
-                                                                      exact
-                                                                      to={Router.buildRouteName(props.match, `/${EXPLORER_TYPE.HOME}/${EXPLORER_TYPE.COURSES}/${prerequisite.course}`)}
-                                                                      activeClassName="active item"
-                                                                    >
-                                                                      {courseSlugToName(prerequisite.course)}
-                                                                      <br />
-                                                                    </NavLink>
-                                                                  )
-                                                                    :
-                                                                    _.map(choices(prerequisite), (choice, choicesIndex) => (
+                                                                    table.map((prerequisite) => (
                                                                       <React.Fragment key={_.uniqueId()}>
                                                                         {
-                                                                          isFirst(choicesIndex) ? (
+                                                                          isSingleChoice(prerequisite.course) ? (
                                                                             <NavLink
                                                                               exact
-                                                                              to={Router.buildRouteName(props.match, `/${EXPLORER_TYPE.HOME}/${EXPLORER_TYPE.COURSES}/${choice}`)}
+                                                                              to={Router.buildRouteName(props.match, `/${EXPLORER_TYPE.HOME}/${EXPLORER_TYPE.COURSES}/${prerequisite.course}`)}
                                                                               activeClassName="active item"
                                                                             >
-                                                                              {courseSlugToName(choice)}
+                                                                              {courseSlugToName(prerequisite.course)}
+                                                                              <br />
                                                                             </NavLink>
-                                                                          )
-                                                                            : (
-                                                                              <React.Fragment>
-                                                                                {/* Not exactly sure where this pops up because even in
+                                                                            )
+                                                                            :
+                                                                            _.map(choices(prerequisite), (choice, choicesIndex) => (
+                                                                              <React.Fragment key={_.uniqueId()}>
+                                                                                {
+                                                                                  isFirst(choicesIndex) ? (
+                                                                                    <NavLink
+                                                                                      exact
+                                                                                      to={Router.buildRouteName(props.match, `/${EXPLORER_TYPE.HOME}/${EXPLORER_TYPE.COURSES}/${choice}`)}
+                                                                                      activeClassName="active item"
+                                                                                    >
+                                                                                      {courseSlugToName(choice)}
+                                                                                    </NavLink>
+                                                                                    )
+                                                                                    : (
+                                                                                      <React.Fragment>
+                                                                                        {/* Not exactly sure where this pops up because even in
                                                                              the original RadGrad I don't see any "or {choice} */}
-                                                                                or
-                                                                                {' '}
-                                                                                <NavLink
-                                                                                  exact
-                                                                                  to={Router.buildRouteName(props.match, `/${EXPLORER_TYPE.HOME}/${EXPLORER_TYPE.COURSES}/${choice}`)}
-                                                                                  activeClassName="active item"
-                                                                                >
-                                                                                  {courseSlugToName(choice)}
-                                                                                </NavLink>
+                                                                                        or
+                                                                                        <NavLink
+                                                                                          exact
+                                                                                          to={Router.buildRouteName(props.match, `/${EXPLORER_TYPE.HOME}/${EXPLORER_TYPE.COURSES}/${choice}`)}
+                                                                                          activeClassName="active item"
+                                                                                        >
+                                                                                          {courseSlugToName(choice)}
+                                                                                        </NavLink>
+                                                                                      </React.Fragment>
+                                                                                    )
+                                                                                }
                                                                               </React.Fragment>
-                                                                          )
-}
+                                                                            ))
+                                                                        }
                                                                       </React.Fragment>
                                                                     ))
-                                                                }
+                                                                  }
                                                               </React.Fragment>
-                                                            ))
+                                                              )
+                                                              :
+                                                              <Item style={{ color: 'grey' }}>None</Item>
                                                           }
-                                                        </React.Fragment>
-                                                      )
-                                                        :
-                                                        <Item style={{ color: 'grey' }}>None</Item>
+                                                        </Grid.Column>
+                                                      ))
                                                     }
-                                                  </Grid.Column>
-                                                ))
-                                              }
-                                            </Grid.Row>
-                                          </Grid>
-                                        )
-                                          : (
-                                            <List horizontal bulleted>
-                                              {
-                                              toValueArray(descriptionPair).map((prereqType) => (
-                                                prereqType.map((prereq) => (
-                                                  <List.Item
-                                                    key={prereq.course}
-                                                    as={NavLink}
-                                                    exact
-                                                    to={Router.buildRouteName(props.match, `/${EXPLORER_TYPE.HOME}/${EXPLORER_TYPE.COURSES}/${prereq.course}`)}
-                                                  >
-                                                    {courseSlugToName(prereq.course)}
-                                                  </List.Item>
-                                                ))
-                                              ))
-                                            }
-                                            </List>
-                                        )
-}
-                                    </React.Fragment>
-                                  )
-                                    : ''
-                                }
+                                                </Grid.Row>
+                                              </Grid>
+                                              )
+                                              : (
+                                                <List horizontal bulleted>
+                                                  {
+                                                    toValueArray(descriptionPair).map((prereqType) => (
+                                                      prereqType.map((prereq) => (
+                                                        <List.Item
+                                                          key={prereq.course}
+                                                          as={NavLink}
+                                                          exact
+                                                          to={Router.buildRouteName(props.match, `/${EXPLORER_TYPE.HOME}/${EXPLORER_TYPE.COURSES}/${prereq.course}`)}
+                                                        >
+                                                          {courseSlugToName(prereq.course)}
+                                                        </List.Item>
+                                                      ))
+                                                    ))
+                                                  }
+                                                </List>
+                                              )
+                                          }
+                                      </React.Fragment>
+                                      )
+                                      : ''
+                                  }
                               </React.Fragment>
-                            )
+                              )
                               : ''
                           }
                         </React.Fragment>
@@ -698,7 +689,7 @@ const ExplorerCoursesWidget = (props: IExplorerCoursesWidgetProps) => {
                   </Grid.Column>
                 </Grid>
               </React.Fragment>
-)
+            )
           }
         </Segment>
       </Segment.Group>
@@ -717,7 +708,7 @@ const ExplorerCoursesWidget = (props: IExplorerCoursesWidgetProps) => {
               </Segment>
             </Grid.Column>
           </Grid>
-        )
+          )
           : ''
       }
     </div>

--- a/app/imports/ui/components/shared/ExplorerMenuNonMobileWidget.tsx
+++ b/app/imports/ui/components/shared/ExplorerMenuNonMobileWidget.tsx
@@ -84,9 +84,7 @@ const ExplorerMenuNonMobileWidget = (props: IExplorerMenuNonMobileWidgetProps) =
               <Button as={Link} to={`${baseRoute}/${EXPLORER_TYPE.HOME}/${props.type}`} style={marginTopStyle}>
                 <Icon name="chevron circle left" />
                 <br />
-                Back to
-                {' '}
-                {getTypeName(props)}
+                Back to {getTypeName(props)}
               </Button>
               {
                 isStudent ? (
@@ -117,9 +115,7 @@ const ExplorerMenuNonMobileWidget = (props: IExplorerMenuNonMobileWidgetProps) =
               <Button as={Link} to={`${baseRoute}/${EXPLORER_TYPE.HOME}/${props.type}`} style={marginTopStyle}>
                 <Icon name="chevron circle left" />
                 <br />
-                Back to
-                {' '}
-                {getTypeName(props)}
+                Back to {getTypeName(props)}
               </Button>
               {
                 isStudent ? (
@@ -226,9 +222,7 @@ const ExplorerMenuNonMobileWidget = (props: IExplorerMenuNonMobileWidgetProps) =
               <Button as={Link} to={`${baseRoute}/${EXPLORER_TYPE.HOME}/${props.type}`} style={marginTopStyle}>
                 <Icon name="chevron circle left" />
                 <br />
-                Back to
-                {' '}
-                {getTypeName(props)}
+                Back to {getTypeName(props)}
               </Button>
               <Header as="h4" dividing>MY CAREER GOALS</Header>
               {

--- a/app/imports/ui/components/shared/ExplorerOpportunitiesWidget.tsx
+++ b/app/imports/ui/components/shared/ExplorerOpportunitiesWidget.tsx
@@ -109,192 +109,6 @@ const ExplorerOpportunitiesWidget = (props: IExplorerOpportunitiesWidgetProps) =
               <Grid stackable columns={2}>
                 <Grid.Column width={9}>
                   {
-                  descriptionPairs.map((descriptionPair) => (
-                    <React.Fragment key={toId(descriptionPair)}>
-                      {
-                        isSame(descriptionPair.label, 'Opportunity Type') ? (
-                          <React.Fragment>
-                            <b>
-                              {descriptionPair.label}
-                              :
-                            </b>
-                            {
-                              descriptionPair.value ? (
-                                <React.Fragment>
-                                  {' '}
-                                  {descriptionPair.value}
-                                  {' '}
-                                  <br />
-                                </React.Fragment>
-                              )
-                                : (
-                                  <React.Fragment>
-                                    {' '}
-                                    N/A
-                                    <br />
-                                  </React.Fragment>
-                              )
-}
-                          </React.Fragment>
-                        )
-                          : ''
-                      }
-                      {
-                        isSame(descriptionPair.label, 'Sponsor') ? (
-                          <React.Fragment>
-                            <b>
-                              {descriptionPair.label}
-                              :
-                            </b>
-                            {
-                              descriptionPair.value ? (
-                                <React.Fragment>
-                                  <span style={breakWordStyle}>
-                                    {' '}
-                                    {descriptionPair.value}
-                                  </span>
-                                  {' '}
-                                  <br />
-                                </React.Fragment>
-                              )
-                                : (
-                                  <React.Fragment>
-                                    {' '}
-                                    N/A
-                                    <br />
-                                  </React.Fragment>
-                              )
-}
-                          </React.Fragment>
-                        )
-                          : ''
-                      }
-                      {
-                        isSame(descriptionPair.label, 'Semesters') ? (
-                          <React.Fragment>
-                            <b>
-                              {descriptionPair.label}
-                              :
-                            </b>
-                            {
-                              descriptionPair.value ? (
-                                <React.Fragment>
-                                  <span
-                                    style={breakWordStyle}
-                                  >
-                                    {' '}
-                                    {replaceTermString(descriptionPair.value)}
-                                  </span>
-                                  <br />
-                                </React.Fragment>
-                              )
-                                : (
-                                  <React.Fragment>
-                                    {' '}
-                                    N/A
-                                    <br />
-                                  </React.Fragment>
-                              )
-}
-                          </React.Fragment>
-                        )
-                          : ''
-                      }
-                      {
-                        isSame(descriptionPair.label, 'Description') ? (
-                          <React.Fragment>
-                            <b>
-                              {descriptionPair.label}
-                              :
-                            </b>
-                            {
-                              descriptionPair.value ? (
-                                <Markdown
-                                  escapeHtml
-                                  source={descriptionPair.value}
-                                  renderers={{ link: (localProps) => Router.renderLink(localProps, match) }}
-                                />
-                              )
-                                :
-                                <React.Fragment> N/A </React.Fragment>
-                            }
-                          </React.Fragment>
-                        )
-                          : ''
-                      }
-                    </React.Fragment>
-                  ))
-                }
-                </Grid.Column>
-                <Grid.Column width={7}>
-                  {
-                  descriptionPairs.map((descriptionPair) => (
-                    <React.Fragment key={toId(descriptionPair)}>
-                      {
-                        isSame(descriptionPair.label, 'Event Date') ? (
-                          <React.Fragment>
-                            <b>
-                              {descriptionPair.label}
-                              :
-                            </b>
-                            {
-                              descriptionPair.value ? (
-                                <React.Fragment>
-                                  <span style={breakWordStyle}>
-                                    {' '}
-                                    {descriptionPair.value.toString()}
-                                  </span>
-                                  <br />
-                                </React.Fragment>
-                              )
-                                : (
-                                  <React.Fragment>
-                                    {' '}
-                                    N/A
-                                    <br />
-                                  </React.Fragment>
-                              )
-}
-                          </React.Fragment>
-                        )
-                          : ''
-                      }
-                      {
-                        isSame(descriptionPair.label, 'Teaser') && teaserUrlHelper(props) ? (
-                          <React.Fragment>
-                            <b>
-                              {descriptionPair.label}
-                              :
-                            </b>
-                            {
-                              descriptionPair.value ? (
-                                <Embed
-                                  active
-                                  autoplay={false}
-                                  source="youtube"
-                                  id={teaserUrlHelper(props)}
-                                />
-                              )
-                                :
-                                <p> N/A </p>
-                            }
-                          </React.Fragment>
-                        )
-                          : ''
-                      }
-                    </React.Fragment>
-                  ))
-                }
-                  <FutureParticipation type="opportunity" item={props.item} />
-                </Grid.Column>
-              </Grid>
-) :
-            (
-              <React.Fragment>
-                No Teaser
-                <Grid stackable columns={2}>
-                  <Grid.Column width={5}>
-                    {
                     descriptionPairs.map((descriptionPair) => (
                       <React.Fragment key={toId(descriptionPair)}>
                         {
@@ -305,24 +119,21 @@ const ExplorerOpportunitiesWidget = (props: IExplorerOpportunitiesWidgetProps) =
                                 :
                               </b>
                               {
-                                descriptionPair.value ? (
-                                  <React.Fragment>
-                                    {' '}
-                                    {descriptionPair.value}
-                                    {' '}
-                                    <br />
-                                  </React.Fragment>
-                                )
-                                  : (
+                                  descriptionPair.value ? (
                                     <React.Fragment>
-                                      {' '}
-                                      N/A
+                                      {descriptionPair.value}
                                       <br />
                                     </React.Fragment>
-                                )
-}
+                                    )
+                                    : (
+                                      <React.Fragment>
+                                        N/A
+                                        <br />
+                                      </React.Fragment>
+                                    )
+                                }
                             </React.Fragment>
-                          )
+                            )
                             : ''
                         }
                         {
@@ -333,36 +144,23 @@ const ExplorerOpportunitiesWidget = (props: IExplorerOpportunitiesWidgetProps) =
                                 :
                               </b>
                               {
-                                descriptionPair.value ? (
-                                  <React.Fragment>
-                                    <span style={breakWordStyle}>
-                                      {' '}
-                                      {descriptionPair.value}
-                                    </span>
-                                    {' '}
-                                    <br />
-                                  </React.Fragment>
-                                )
-                                  : (
+                                  descriptionPair.value ? (
                                     <React.Fragment>
-                                      {' '}
-                                      N/A
+                                      <span style={breakWordStyle}> {descriptionPair.value}</span>
                                       <br />
                                     </React.Fragment>
-                                )
-}
+                                    )
+                                    : (
+                                      <React.Fragment>
+                                        N/A
+                                        <br />
+                                      </React.Fragment>
+                                    )
+                                }
                             </React.Fragment>
-                          )
+                            )
                             : ''
                         }
-                      </React.Fragment>
-                    ))
-                  }
-                  </Grid.Column>
-                  <Grid.Column width={11}>
-                    {
-                    descriptionPairs.map((descriptionPair) => (
-                      <React.Fragment key={toId(descriptionPair)}>
                         {
                           isSame(descriptionPair.label, 'Semesters') ? (
                             <React.Fragment>
@@ -371,68 +169,23 @@ const ExplorerOpportunitiesWidget = (props: IExplorerOpportunitiesWidgetProps) =
                                 :
                               </b>
                               {
-                                descriptionPair.value ? (
-                                  <React.Fragment>
-                                    <span
-                                      style={breakWordStyle}
-                                    >
-                                      {' '}
-                                      {replaceTermString(descriptionPair.value)}
-                                    </span>
-                                    <br />
-                                  </React.Fragment>
-                                )
-                                  : (
+                                  descriptionPair.value ? (
                                     <React.Fragment>
-                                      {' '}
-                                      N/A
+                                      <span style={breakWordStyle}> {replaceTermString(descriptionPair.value)}</span>
                                       <br />
                                     </React.Fragment>
-                                )
-}
+                                    )
+                                    : (
+                                      <React.Fragment>
+                                        N/A
+                                        <br />
+                                      </React.Fragment>
+                                    )
+                                }
                             </React.Fragment>
-                          )
+                            )
                             : ''
                         }
-                        {
-                          isSame(descriptionPair.label, 'Event Date') ? (
-                            <React.Fragment>
-                              <b>
-                                {descriptionPair.label}
-                                :
-                              </b>
-                              {
-                                descriptionPair.value ? (
-                                  <React.Fragment>
-                                    <span style={breakWordStyle}>
-                                      {' '}
-                                      {descriptionPair.value.toString()}
-                                    </span>
-                                    <br />
-                                  </React.Fragment>
-                                )
-                                  : (
-                                    <React.Fragment>
-                                      {' '}
-                                      N/A
-                                      <br />
-                                    </React.Fragment>
-                                )
-}
-                            </React.Fragment>
-                          )
-                            : ''
-                        }
-                      </React.Fragment>
-                    ))
-                  }
-                  </Grid.Column>
-                </Grid>
-                <Grid stackable columns={1}>
-                  <Grid.Column style={zeroMarginTopStyle}>
-                    {
-                    descriptionPairs.map((descriptionPair) => (
-                      <React.Fragment key={toId(descriptionPair)}>
                         {
                           isSame(descriptionPair.label, 'Description') ? (
                             <React.Fragment>
@@ -441,23 +194,235 @@ const ExplorerOpportunitiesWidget = (props: IExplorerOpportunitiesWidgetProps) =
                                 :
                               </b>
                               {
-                                descriptionPair.value ? (
-                                  <Markdown
-                                    escapeHtml
-                                    source={descriptionPair.value}
-                                    renderers={{ link: (localProps) => Router.renderLink(localProps, match) }}
-                                  />
-                                )
-                                  :
-                                  <React.Fragment> N/A </React.Fragment>
-                              }
+                                  descriptionPair.value ? (
+                                    <Markdown
+                                      escapeHtml
+                                      source={descriptionPair.value}
+                                      renderers={{ link: (localProps) => Router.renderLink(localProps, match) }}
+                                    />
+                                    )
+                                    :
+                                    <React.Fragment> N/A </React.Fragment>
+                                }
                             </React.Fragment>
-                          )
+                            )
                             : ''
                         }
                       </React.Fragment>
                     ))
                   }
+                </Grid.Column>
+                <Grid.Column width={7}>
+                  {
+                    descriptionPairs.map((descriptionPair) => (
+                      <React.Fragment key={toId(descriptionPair)}>
+                        {
+                          isSame(descriptionPair.label, 'Event Date') ? (
+                            <React.Fragment>
+                              <b>
+                                {descriptionPair.label}
+                                :
+                              </b>
+                              {
+                                  descriptionPair.value ? (
+                                    <React.Fragment>
+                                      <span style={breakWordStyle}>{descriptionPair.value.toString()}</span>
+                                      <br />
+                                    </React.Fragment>
+                                    )
+                                    : (
+                                      <React.Fragment>
+                                        N/A
+                                        <br />
+                                      </React.Fragment>
+                                    )
+                                }
+                            </React.Fragment>
+                            )
+                            : ''
+                        }
+                        {
+                          isSame(descriptionPair.label, 'Teaser') && teaserUrlHelper(props) ? (
+                            <React.Fragment>
+                              <b>
+                                {descriptionPair.label}
+                                :
+                              </b>
+                              {
+                                  descriptionPair.value ? (
+                                    <Embed
+                                      active
+                                      autoplay={false}
+                                      source="youtube"
+                                      id={teaserUrlHelper(props)}
+                                    />
+                                    )
+                                    :
+                                    <p> N/A </p>
+                                }
+                            </React.Fragment>
+                            )
+                            : ''
+                        }
+                      </React.Fragment>
+                    ))
+                  }
+                  <FutureParticipation type="opportunity" item={props.item} />
+                </Grid.Column>
+              </Grid>
+            ) :
+            (
+              <React.Fragment>
+                No Teaser
+                <Grid stackable columns={2}>
+                  <Grid.Column width={5}>
+                    {
+                      descriptionPairs.map((descriptionPair) => (
+                        <React.Fragment key={toId(descriptionPair)}>
+                          {
+                            isSame(descriptionPair.label, 'Opportunity Type') ? (
+                              <React.Fragment>
+                                <b>
+                                  {descriptionPair.label}
+                                  :
+                                </b>
+                                {
+                                    descriptionPair.value ? (
+                                      <React.Fragment>
+                                        {descriptionPair.value}
+                                        <br />
+                                      </React.Fragment>
+                                      )
+                                      : (
+                                        <React.Fragment>
+                                          N/A
+                                          <br />
+                                        </React.Fragment>
+                                      )
+                                  }
+                              </React.Fragment>
+                              )
+                              : ''
+                          }
+                          {
+                            isSame(descriptionPair.label, 'Sponsor') ? (
+                              <React.Fragment>
+                                <b>
+                                  {descriptionPair.label}
+                                  :
+                                </b>
+                                {
+                                    descriptionPair.value ? (
+                                      <React.Fragment>
+                                        <span style={breakWordStyle}>{descriptionPair.value}</span>
+                                        <br />
+                                      </React.Fragment>
+                                      )
+                                      : (
+                                        <React.Fragment>
+                                          N/A
+                                          <br />
+                                        </React.Fragment>
+                                      )
+                                  }
+                              </React.Fragment>
+                              )
+                              : ''
+                          }
+                        </React.Fragment>
+                      ))
+                    }
+                  </Grid.Column>
+                  <Grid.Column width={11}>
+                    {
+                      descriptionPairs.map((descriptionPair) => (
+                        <React.Fragment key={toId(descriptionPair)}>
+                          {
+                            isSame(descriptionPair.label, 'Semesters') ? (
+                              <React.Fragment>
+                                <b>
+                                  {descriptionPair.label}
+                                  :
+                                </b>
+                                {
+                                    descriptionPair.value ? (
+                                      <React.Fragment>
+                                        <span style={breakWordStyle}>{replaceTermString(descriptionPair.value)}</span>
+                                        <br />
+                                      </React.Fragment>
+                                      )
+                                      : (
+                                        <React.Fragment>
+                                          {' '}
+                                          N/A
+                                          <br />
+                                        </React.Fragment>
+                                      )
+                                  }
+                              </React.Fragment>
+                              )
+                              : ''
+                          }
+                          {
+                            isSame(descriptionPair.label, 'Event Date') ? (
+                              <React.Fragment>
+                                <b>
+                                  {descriptionPair.label}
+                                  :
+                                </b>
+                                {
+                                    descriptionPair.value ? (
+                                      <React.Fragment>
+                                        <span style={breakWordStyle}>{descriptionPair.value.toString()}</span>
+                                        <br />
+                                      </React.Fragment>
+                                      )
+                                      : (
+                                        <React.Fragment>
+                                          N/A
+                                          <br />
+                                        </React.Fragment>
+                                      )
+                                  }
+                              </React.Fragment>
+                              )
+                              : ''
+                          }
+                        </React.Fragment>
+                      ))
+                    }
+                  </Grid.Column>
+                </Grid>
+                <Grid stackable columns={1}>
+                  <Grid.Column style={zeroMarginTopStyle}>
+                    {
+                      descriptionPairs.map((descriptionPair) => (
+                        <React.Fragment key={toId(descriptionPair)}>
+                          {
+                            isSame(descriptionPair.label, 'Description') ? (
+                              <React.Fragment>
+                                <b>
+                                  {descriptionPair.label}
+                                  :
+                                </b>
+                                {
+                                    descriptionPair.value ? (
+                                      <Markdown
+                                        escapeHtml
+                                        source={descriptionPair.value}
+                                        renderers={{ link: (localProps) => Router.renderLink(localProps, match) }}
+                                      />
+                                      )
+                                      :
+                                      <React.Fragment> N/A </React.Fragment>
+                                  }
+                              </React.Fragment>
+                              )
+                              : ''
+                          }
+                        </React.Fragment>
+                      ))
+                    }
                   </Grid.Column>
                 </Grid>
                 <Grid stackable>
@@ -467,7 +432,7 @@ const ExplorerOpportunitiesWidget = (props: IExplorerOpportunitiesWidgetProps) =
                   </Grid.Column>
                 </Grid>
               </React.Fragment>
-)}
+            )}
         </Segment>
         <Segment>
           <StudentExplorerReviewWidget

--- a/app/imports/ui/components/shared/ModerationColumnWidget.tsx
+++ b/app/imports/ui/components/shared/ModerationColumnWidget.tsx
@@ -18,11 +18,7 @@ const ModerationColumnWidget = (props: IModerationColumn) => (
   <div>
     <Segment>
       <Header as="h4" textAlign="left" dividing>
-        PENDING
-        {props.type}
-        {' '}
-        REVIEWS
-        {' '}
+        PENDING {props.type} REVIEWS
       </Header>
       {props.isReview && props.reviews.length > 0 ? (
         <Item.Group divided>
@@ -58,10 +54,7 @@ const ModerationColumnWidget = (props: IModerationColumn) => (
               : (
                 <Container textAlign="left">
                   <i>
-                    No pending
-                    {props.type.toLowerCase()}
-                    {' '}
-                    reviews
+                    No pending {props.type.toLowerCase()} reviews
                   </i>
                 </Container>
             )

--- a/app/imports/ui/components/shared/ModerationQuestionCardWidget.tsx
+++ b/app/imports/ui/components/shared/ModerationQuestionCardWidget.tsx
@@ -66,9 +66,7 @@ const ModerationQuestionCardWidget = (props: IModerationQuestionCardWidget) => {
 
   return (
     <Container textAlign="left">
-      <strong>Question: </strong>
-      {' '}
-      {props.question.question}
+      <strong>Question:</strong> {props.question.question}
       <Segment>
         <Form>
           <Form.TextArea label="Moderator Comments" value={moderatorCommentState} onChange={handleChange} />

--- a/app/imports/ui/components/shared/PendingVerificationsWidget.tsx
+++ b/app/imports/ui/components/shared/PendingVerificationsWidget.tsx
@@ -84,17 +84,9 @@ const PendingVerificationsWidget = (props: IPendingVerificationsWidgetProps) => 
             </Grid.Row>
             <Grid.Row columns={2} style={{ paddingTop: '0px', paddingBottom: '0px' }}>
               <Grid.Column>
-                Student:
-                {' '}
-                {studentProfile(ele).firstName}
-                {' '}
-                {cachedStudent.lastName}
+                Student: {studentProfile(ele).firstName} {cachedStudent.lastName}
                 <br />
-                Sponsor:
-                {' '}
-                {sponsorProfile(ele).firstName}
-                {' '}
-                {cachedSponsor.lastName}
+                Sponsor: {sponsorProfile(ele).firstName} {cachedSponsor.lastName}
                 <br />
                 <Form style={{ paddingTop: '14px' }}>
                   <Form.Input
@@ -136,18 +128,7 @@ const PendingVerificationsWidget = (props: IPendingVerificationsWidgetProps) => 
                 <br />
                 {ele.processed.map((elem: IProcessed, ind) => (
                   <React.Fragment key={elem.verifier}>
-                    Processed:
-                    {' '}
-                    {moment(elem.date).calendar()}
-                    {' '}
-                    by
-                    {' '}
-                    {elem.verifier}
-                    {' '}
-                    (
-                    {elem.status}
-                    {elem.feedback ? `, ${elem.feedback}` : ''}
-                    )
+                    Processed: {moment(elem.date).calendar()} by {elem.verifier} ({elem.status}{elem.feedback ? `, ${elem.feedback}` : ''})
                     <br />
                   </React.Fragment>
                 ))}

--- a/app/imports/ui/components/student/DegreeExperiencePlannerWidget.tsx
+++ b/app/imports/ui/components/student/DegreeExperiencePlannerWidget.tsx
@@ -212,9 +212,7 @@ const DEPWidget = (props: IDePProps) => {
           </Grid.Column>
           <Grid.Column textAlign="center">
             <Button color="green" onClick={handleAddYear}>
-              <Icon name="plus circle" />
-              {' '}
-              Add Academic Year
+              <Icon name="plus circle" /> Add Academic Year
             </Button>
           </Grid.Column>
           <Grid.Column textAlign="right">

--- a/app/imports/ui/components/student/InspectorCourseMenu.tsx
+++ b/app/imports/ui/components/student/InspectorCourseMenu.tsx
@@ -77,9 +77,7 @@ const InspectorCourseMenu = (props: IInpectorCourseMenuProps) => {
               <Dropdown.Menu>
                 {_.map(courses, (c) => (
                   <Dropdown.Item key={c._id} value={c._id} onClick={handleClick}>
-                    {c.num}
-                    {' '}
-                    {c.shortName}
+                    {c.num} {c.shortName}
                   </Dropdown.Item>
                 ))}
               </Dropdown.Menu>

--- a/app/imports/ui/components/student/MentorQuestionAnswerWidget.tsx
+++ b/app/imports/ui/components/student/MentorQuestionAnswerWidget.tsx
@@ -24,14 +24,7 @@ const MentorQuestionAnswerWidget = (props: IQuestionAnswersWidgetProps) => {
           <Image src={mentor.picture} size="mini" />
           <List.Content>
             {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
-            <a onClick={toggleFullSize}>
-              {mentor.firstName}
-              {' '}
-              {mentor.lastName}
-              {' '}
-            </a>
-            {' '}
-            answered:
+            <a onClick={toggleFullSize}>{mentor.firstName} {mentor.lastName}</a> answered:
             <ExplorerUsersWidget
               userProfile={mentor}
               isActive={isActiveState}

--- a/app/imports/ui/components/student/StudentAboutMeWidget.tsx
+++ b/app/imports/ui/components/student/StudentAboutMeWidget.tsx
@@ -85,9 +85,7 @@ const StudentAboutMeWidget = (props: IStudentAboutMeWidgetProps) => {
                     const route = Router.buildRouteName(match, `/${EXPLORER_TYPE.HOME}/${EXPLORER_TYPE.CAREERGOALS}/${slugName}`);
                     return (
                       <Label key={careerGoal._id} as={Link} to={route} size="tiny">
-                        <Icon name="suitcase" fitted />
-                        {' '}
-                        {careerGoal.name}
+                        <Icon name="suitcase" fitted /> {careerGoal.name}
                       </Label>
                     );
                   })
@@ -106,9 +104,7 @@ const StudentAboutMeWidget = (props: IStudentAboutMeWidgetProps) => {
                   const route = Router.buildRouteName(match, `/${EXPLORER_TYPE.HOME}/${EXPLORER_TYPE.INTERESTS}/${slugName}`);
                   return (
                     <Label key={interest._id} as={Link} to={route} size="tiny">
-                      <Icon name="star" fitted />
-                      {' '}
-                      {interest.name}
+                      <Icon name="star" fitted /> {interest.name}
                     </Label>
                   );
                 })
@@ -129,9 +125,7 @@ const StudentAboutMeWidget = (props: IStudentAboutMeWidgetProps) => {
                     const route = Router.buildRouteName(match, `/${EXPLORER_TYPE.HOME}/${EXPLORER_TYPE.ACADEMICPLANS}/${slugName}`);
                     return (
                       <Label key={plan._id} as={Link} to={route} size="tiny">
-                        <Icon name="map outline" fitted />
-                        {' '}
-                        {plan.name}
+                        <Icon name="map outline" fitted /> {plan.name}
                       </Label>
                     );
                   })

--- a/app/imports/ui/components/student/StudentExplorerReviewWidget.tsx
+++ b/app/imports/ui/components/student/StudentExplorerReviewWidget.tsx
@@ -81,9 +81,7 @@ const StudentExplorerReviewWidget = (props: IStudentExplorerReviewWidgetProps) =
   return (
     <div className="ui padded container">
       <Header as="h4" dividing style={uppercaseStyle}>
-        {reviewType}
-        {' '}
-        REVIEWS
+        {reviewType} REVIEWS
       </Header>
 
       <List verticalAlign="middle" relaxed="very" divided>
@@ -130,10 +128,7 @@ const StudentExplorerReviewWidget = (props: IStudentExplorerReviewWidgetProps) =
                         : (
                           <p>
                             <i>
-                              You must complete this
-                              {` ${reviewType}`}
-                              {' '}
-                              first to leave a review.
+                              You must complete this {` ${reviewType}`} first to leave a review.
                             </i>
                           </p>
                         )

--- a/app/imports/ui/components/student/StudentIceColumn.tsx
+++ b/app/imports/ui/components/student/StudentIceColumn.tsx
@@ -132,12 +132,8 @@ const StudentIceColumn = (props: IStudentIceColumnProps) => {
       <Accordion.Title active={verifiedColumnOpenState} onClick={handleVerifiedColumnClick}>
         <Icon name="dropdown" />
         Verified
-        <div
-          className={`ui right floated ${verifiedColor}`}
-        >
-          {earnedICEPoints}
-          {' '}
-          pts
+        <div className={`ui right floated ${verifiedColor}`}>
+          {earnedICEPoints} pts
         </div>
       </Accordion.Title>
       <Accordion.Content active={verifiedColumnOpenState}>
@@ -154,13 +150,7 @@ const StudentIceColumn = (props: IStudentIceColumnProps) => {
       <Accordion.Title active={unVerifiedColumnOpenState} onClick={handleUnVerifiedColumnClick}>
         <Icon name="dropdown" />
         Unverified
-        <div
-          className={`ui right floated ${unverifiedColor}`}
-        >
-          {unverifiedICEPoints}
-          {' '}
-          pts
-        </div>
+        <div className={`ui right floated ${unverifiedColor}`}>{unverifiedICEPoints} pts</div>
       </Accordion.Title>
       <Accordion.Content active={unVerifiedColumnOpenState}>
         <StudentIceColumnUnverified

--- a/app/imports/ui/components/student/StudentIceColumnRecommended.tsx
+++ b/app/imports/ui/components/student/StudentIceColumnRecommended.tsx
@@ -163,19 +163,13 @@ const StudentIceColumnRecommended = (props: IStudentIceColumnRecommendedProps) =
     <React.Fragment>
       {matchingPoints(100, earnedICEPoints) ? (
         <p>
-          Congratulations! You have 100 (or more) verified
-          {type}
-          {' '}
-          points!
+          Congratulations! You have 100 (or more) verified {type} points!
         </p>
       )
         :
         matchingPoints(100, projectedICEPoints) ? (
           <p>
-            You already have at least 100 verified or unverified
-            {type}
-            {' '}
-            points.
+            You already have at least 100 verified or unverified {type} points.
           </p>
         )
           :
@@ -184,10 +178,7 @@ const StudentIceColumnRecommended = (props: IStudentIceColumnRecommendedProps) =
             : (
               <React.Fragment>
                 <p>
-                  Consider the following to acquire 100
-                  {type}
-                  {' '}
-                  points.
+                  Consider the following to acquire 100 {type} points.
                 </p>
                 <List>
                   {recommendedEvents(projectedICEPoints, props).map((event) => {
@@ -199,19 +190,12 @@ const StudentIceColumnRecommended = (props: IStudentIceColumnRecommendedProps) =
                     <List.Item key={event._id}>
                       {type === 'Competency' ? (
                         <Link to={courseRoute}>
-                          <b>+9</b>
-                          {' '}
-                          {event.shortName}
+                          <b>+9</b> {event.shortName}
                         </Link>
                       )
                         : (
                           <Link to={opportunityRoute}>
-                            <b>
-                              +
-                              {icePoints(event.ice)}
-                            </b>
-                            {' '}
-                            {event.name}
+                            <b>+{icePoints(event.ice)}</b> {event.name}
                           </Link>
                       )}
                     </List.Item>

--- a/app/imports/ui/components/student/StudentIceColumnUnverified.tsx
+++ b/app/imports/ui/components/student/StudentIceColumnUnverified.tsx
@@ -120,13 +120,7 @@ const StudentIceColumnUnverified = (props: IStudentIceColumnUnverifiedProps) => 
         : (
           <React.Fragment>
             <p>
-              You have a total of
-              {remainingPoints}
-              {' '}
-              unverified
-              {type}
-              {' '}
-              points.
+              You have a total of {remainingPoints} unverified {type} points.
             </p>
             <List relaxed="very">
               {years(props).map((year) => (
@@ -148,12 +142,7 @@ const StudentIceColumnUnverified = (props: IStudentIceColumnUnverifiedProps) => 
                               key={`${opportunitySlug}-${route}-${points}-${oName}`}
                               to={route}
                             >
-                              <b>
-                                +
-                                {points}
-                              </b>
-                              {' '}
-                              {oName}
+                              <b>+{points}</b> {oName}
                               <br />
                             </Link>
                           );
@@ -168,12 +157,7 @@ const StudentIceColumnUnverified = (props: IStudentIceColumnUnverifiedProps) => 
                               key={`${courseSlug}-${route}-${points}-${cName}`}
                               to={route}
                             >
-                              <b>
-                                +
-                                {points}
-                              </b>
-                              {' '}
-                              {cName}
+                              <b>+{points}</b> {cName}
                               <br />
                             </Link>
                           );

--- a/app/imports/ui/components/student/StudentIceColumnVerified.tsx
+++ b/app/imports/ui/components/student/StudentIceColumnVerified.tsx
@@ -121,13 +121,7 @@ const StudentIceColumnVerified = (props: IStudentIceColumnVerifiedProps) => {
         : (
           <React.Fragment>
             <p>
-              You have
-              {earnedICEPoints}
-              {' '}
-              verified
-              {type}
-              {' '}
-              points for the following:
+              You have {earnedICEPoints} verified {type} points for the following:
             </p>
             <List relaxed="very">
               {years(props).map((year) => (
@@ -171,9 +165,7 @@ const StudentIceColumnVerified = (props: IStudentIceColumnVerifiedProps) => {
                                 <b>
                                   +
                                   {points}
-                                </b>
-                                {' '}
-                                {courseName(event as ICourseInstance)}
+                                </b> {courseName(event as ICourseInstance)}
                                 <br />
                               </Link>
                             );

--- a/app/imports/ui/components/student/StudentMentorSpaceMentorDirectoryAccordion.tsx
+++ b/app/imports/ui/components/student/StudentMentorSpaceMentorDirectoryAccordion.tsx
@@ -33,10 +33,7 @@ const StudentMentorSpaceMentorDirectoryAccordion = (props: IStudentMentorSpaceMe
                   <Image src={mentor.picture} size="mini" />
                   <List.Content>
                     <a href="#">
-                      {mentor.firstName}
-                      {' '}
-                      {mentor.lastName}
-                      {' '}
+                      {mentor.firstName} {mentor.lastName}
                     </a>
                     <List.Description>
                       {mentor.career}
@@ -54,20 +51,11 @@ const StudentMentorSpaceMentorDirectoryAccordion = (props: IStudentMentorSpaceMe
                 <br />
               </Segment>
               <Segment basic size="tiny">
-                {mentor.firstName}
-                {' '}
-                {mentor.lastName}
-                {' '}
-                is based in
-                {' '}
-                {mentor.location}
+                {mentor.firstName} {mentor.lastName} is based in {mentor.location}
                 <br />
-                <Icon name="mail" />
-                {' '}
-                <a href={`mailto:${mentor.username}`}>{mentor.username}</a>
+                <Icon name="mail" /> <a href={`mailto:${mentor.username}`}>{mentor.username}</a>
                 <br />
                 <Icon name="linkedin" />
-                {' '}
                 <a href={`https://www.linkedin.com/in/${mentor.linkedin}`}>{mentor.linkedin}</a>
                 <br />
               </Segment>

--- a/app/imports/ui/components/student/StudentMentorSpaceQuestionsAccordion.tsx
+++ b/app/imports/ui/components/student/StudentMentorSpaceQuestionsAccordion.tsx
@@ -41,9 +41,7 @@ const StudentMentorSpaceQuestionsAccordion = (props: IStudentMentorSpaceQuestion
                     {q.question}
                   </Grid.Column>
                   <Grid.Column width={2} textAlign="right">
-                    {answerCount[ind]}
-                    {' '}
-                    {answerCount[ind] > 1 ? ' answers' : ' answer'}
+                    {answerCount[ind]} {answerCount[ind] > 1 ? ' answers' : ' answer'}
                   </Grid.Column>
                 </Grid.Row>
               </Grid>

--- a/app/imports/ui/components/student/VerificationRequestStatus.tsx
+++ b/app/imports/ui/components/student/VerificationRequestStatus.tsx
@@ -17,14 +17,10 @@ const VerificationRequestStatus = (props: IVerificationRequestStatusProps) => {
       <Divider />
       <Header>REQUEST STATUS</Header>
       <span>
-        <strong>Date Submitted:</strong>
-        {' '}
-        {whenSubmitted}
+        <strong>Date Submitted:</strong> {whenSubmitted}
       </span>
       <span>
-        <strong>Status:</strong>
-        {' '}
-        {props.request.status}
+        <strong>Status:</strong> {props.request.status}
       </span>
       <strong>Documentation:</strong>
       {' '}

--- a/app/imports/ui/pages/landing/LandingAcademicPlansCardExplorer.tsx
+++ b/app/imports/ui/pages/landing/LandingAcademicPlansCardExplorer.tsx
@@ -45,11 +45,7 @@ const renderPage = (props: IAcademicPlansCardExplorerProps) => {
           <Grid.Column width={11}>
             <Segment padded style={{ overflow: 'auto', maxHeight: 750 }}>
               <Header as="h4" dividing>
-                <span>ACADEMIC PLANS</span>
-                {' '}
-                (
-                {props.count}
-                )
+                <span>ACADEMIC PLANS</span> ({props.count})
               </Header>
               <Card.Group stackable itemsPerRow={2} style={inlineStyle}>
                 {props.academicPlans.map((plan) => (

--- a/app/imports/ui/pages/landing/LandingCareerGoalsCardExplorer.tsx
+++ b/app/imports/ui/pages/landing/LandingCareerGoalsCardExplorer.tsx
@@ -45,11 +45,7 @@ const renderPage = (props: ICareerGoalsCardExplorerProps) => {
           <Grid.Column width={11}>
             <Segment padded style={{ overflow: 'auto', maxHeight: 750 }}>
               <Header as="h4" dividing>
-                <span>CAREER GOALS</span>
-                {' '}
-                (
-                {props.count}
-                )
+                <span>CAREER GOALS</span> ({props.count})
               </Header>
               <Card.Group stackable itemsPerRow={2} style={inlineStyle}>
                 {props.careerGoals.map((goal) => (

--- a/app/imports/ui/pages/landing/LandingCourseExplorer.tsx
+++ b/app/imports/ui/pages/landing/LandingCourseExplorer.tsx
@@ -53,27 +53,17 @@ const LandingCourseExplorer = (props: ICourseExplorerProps) => {
             <Segment padded style={{ overflow: 'auto', maxHeight: 750 }}>
               <Header as="h4" dividing>
                 <span>
-                  {props.course.shortName}
-                  {' '}
-                  (
-                  {props.course.name}
-                  )
+                  {props.course.shortName} ({props.course.name})
                 </span>
               </Header>
               <Grid columns={2} stackable>
                 <Grid.Column width="six">
-                  <b>Course Number:</b>
-                  {' '}
-                  {props.course.num}
+                  <b>Course Number:</b>  {props.course.num}
                   <br />
-                  <b>Credit Hours:</b>
-                  {' '}
-                  {props.course.creditHrs}
+                  <b>Credit Hours:</b> {props.course.creditHrs}
                 </Grid.Column>
                 <Grid.Column width="ten">
-                  <b>Syllabus</b>
-                  {' '}
-                  {props.course.syllabus ?
+                  <b>Syllabus</b> {props.course.syllabus ?
                     <a href={props.course.syllabus}>{props.course.syllabus}</a> : 'None available'}
                 </Grid.Column>
               </Grid>

--- a/app/imports/ui/pages/landing/LandingCoursesCardExplorer.tsx
+++ b/app/imports/ui/pages/landing/LandingCoursesCardExplorer.tsx
@@ -45,11 +45,7 @@ const renderPage = (props:ICoursesCardExplorerProps) => {
           <Grid.Column width={11}>
             <Segment padded style={{ overflow: 'auto', maxHeight: 750 }}>
               <Header as="h4" dividing>
-                <span>COURSES</span>
-                {' '}
-                (
-                {props.count}
-                )
+                <span>COURSES</span> ({props.count})
               </Header>
               <Card.Group stackable itemsPerRow={2} style={inlineStyle}>
                 {props.courses.map((goal) => (

--- a/app/imports/ui/pages/landing/LandingDegreesCardExplorer.tsx
+++ b/app/imports/ui/pages/landing/LandingDegreesCardExplorer.tsx
@@ -45,11 +45,7 @@ const renderPage = (props: IDegreesCardExplorerProps) => {
           <Grid.Column width={11}>
             <Segment padded style={{ overflow: 'auto', maxHeight: 750 }}>
               <Header as="h4" dividing>
-                <span>DESIRED DEGREES</span>
-                {' '}
-                (
-                {props.count}
-                )
+                <span>DESIRED DEGREES</span> ({props.count})
               </Header>
               <Card.Group stackable itemsPerRow={2} style={inlineStyle}>
                 {props.desiredDegrees.map((goal) => (

--- a/app/imports/ui/pages/landing/LandingInterestsCardExplorer.tsx
+++ b/app/imports/ui/pages/landing/LandingInterestsCardExplorer.tsx
@@ -45,11 +45,7 @@ const renderPage = (props: IInterestsCardExplorerProps) => {
           <Grid.Column width={11}>
             <Segment padded style={{ overflow: 'auto', maxHeight: 750 }}>
               <Header as="h4" dividing>
-                <span>INTERESTS</span>
-                {' '}
-                (
-                {props.count}
-                )
+                <span>INTERESTS</span> ({props.count})
               </Header>
               <Card.Group stackable itemsPerRow={2} style={inlineStyle}>
                 {props.interests.map((interest) => (

--- a/app/imports/ui/pages/landing/LandingOpportunitiesCardExplorer.tsx
+++ b/app/imports/ui/pages/landing/LandingOpportunitiesCardExplorer.tsx
@@ -44,11 +44,7 @@ const renderPage = (props: IOpportunitiesCardExplorerProps) => {
           <Grid.Column width={11}>
             <Segment padded style={{ overflow: 'auto', maxHeight: 750 }}>
               <Header as="h4" dividing>
-                <span>OPPORTUNITIES</span>
-                {' '}
-                (
-                {props.count}
-                )
+                <span>OPPORTUNITIES</span> ({props.count})
               </Header>
               <Card.Group stackable itemsPerRow={2} style={inlineStyle}>
                 {props.opportunities.map((opportunity) => (

--- a/app/imports/ui/pages/landing/LandingOpportunityExplorer.tsx
+++ b/app/imports/ui/pages/landing/LandingOpportunityExplorer.tsx
@@ -68,15 +68,11 @@ const LandingOpportunityExplorer = (props: IOpportunityExplorerProps) => {
               </Header>
               <Grid columns={2} stackable>
                 <Grid.Column width="six">
-                  <b>Opportunity Type:</b>
-                  {' '}
-                  {getOpportunityTypeName(props.opportunity.opportunityTypeID)}
+                  <b>Opportunity Type:</b> {getOpportunityTypeName(props.opportunity.opportunityTypeID)}
                   <br />
                 </Grid.Column>
                 <Grid.Column width="ten">
-                  <b>{(props.quarters ? 'Quarters' : 'Semesters')}</b>
-                  {' '}
-                  {semesters(props.opportunity)}
+                  <b>{(props.quarters ? 'Quarters' : 'Semesters')}</b> {semesters(props.opportunity)}
                 </Grid.Column>
               </Grid>
               <b>Description:</b>

--- a/app/package.json
+++ b/app/package.json
@@ -213,7 +213,9 @@
       "react/jsx-fragments": "off",
       "react/jsx-props-no-spreading": "off",
       "react/prefer-stateless-function": "off",
-      "react/sort-comp": "off"
+      "react/sort-comp": "off",
+      "react/jsx-one-expression-per-line": "off",
+      "react/jsx-closing-tag-location": "off"
     }
   }
 }


### PR DESCRIPTION
[comment]: # "Before continuining with the rest of the Pull Request, make sure the *Title* of this Pull Request contains the following"
[comment]: # "format: [branch] - Short description"
[comment]: # "Where *branch* is the branch you're merging from into master and short description describes the major changes of the PR."

Status: ✅ 

**What this accomplishes**
Turns off the following ESLint rules: "react/jsx-one-expression-per-line" and "react/jsx-closing-tag-location"

**What contributors need to know**
Because of the first rule, ESLint automatically added `{' '}` instances to comply with that rule when it was enabled. In this PR, I deleted as much of those instances as I could before I realized there were simply too many as there were hundreds of instances in 40+ files. I left it as it is so any future contributors/maintainers working on the source code should remove those instances if they do find them. 

There might also be some small UI issues (no proper spacing) that might have occurred as a result of me deleting these instances. Need to skim the parts of the site corresponding to the changed files in this PR to make correct any improper spacing. 
