### PR TITLE
[issue-247] Improve UI display for typeData for Admin Analytics

### DIFF
--- a/app/imports/ui/components/admin/AnalyticsOverheadAnalysisPage/UserSessionOverheadModal.tsx
+++ b/app/imports/ui/components/admin/AnalyticsOverheadAnalysisPage/UserSessionOverheadModal.tsx
@@ -28,8 +28,7 @@ const UserSessionOverheadModal = (props: IUserSessionOverheadModalProps) => {
       <Modal.Header>User Interactions: <span style={fullNameStyle}>{fullName}</span></Modal.Header>
       <Modal.Content>
         <div style={tableStyle}>
-          {/* TODO UI: Make the typeData column a fixed size and have words break-word */}
-          <Table celled padded>
+          <Table celled padded columns={3}>
             <Table.Header>
               <Table.Row>
                 <Table.HeaderCell>Type</Table.HeaderCell>
@@ -41,8 +40,7 @@ const UserSessionOverheadModal = (props: IUserSessionOverheadModalProps) => {
               {userInteractionsByUser.map((interaction) => (
                 <Table.Row key={_.uniqueId(`${interaction.username}-${interaction.type}`)}>
                   <Table.Cell>{interaction.type}</Table.Cell>
-                  {/* TODO UI: Improve the output format string of typeData */}
-                  <Table.Cell>{interaction.typeData}</Table.Cell>
+                  <Table.Cell>{interaction.typeData.join(', ')}</Table.Cell>
                   <Table.Cell>{formatDate(interaction.timestamp)}</Table.Cell>
                 </Table.Row>
               ))}

--- a/app/imports/ui/components/admin/AnalyticsUserInteractionsPage/AdminAnalyticsUserInteractionsWidget.tsx
+++ b/app/imports/ui/components/admin/AnalyticsUserInteractionsPage/AdminAnalyticsUserInteractionsWidget.tsx
@@ -78,7 +78,7 @@ const AdminAnalyticsUserInteractionsWidget = (props: IAdminAnalyticsUserInteract
         <Header as="h4" dividing>
           USER INTERACTIONS: <span style={nameStyle}>{getStudentName()}</span>
         </Header>
-        <Table celled>
+        <Table celled columns={3}>
           <Table.Header>
             <Table.Row>
               <Table.HeaderCell>Type</Table.HeaderCell>
@@ -90,7 +90,7 @@ const AdminAnalyticsUserInteractionsWidget = (props: IAdminAnalyticsUserInteract
             {interactions.map((interaction) => (
               <Table.Row key={interaction._id}>
                 <Table.Cell>{interaction.type}</Table.Cell>
-                <Table.Cell>{interaction.typeData}</Table.Cell>
+                <Table.Cell>{interaction.typeData.join(', ')}</Table.Cell>
                 <Table.Cell>{moment(interaction.timestamp).format('MM/DD/YY HH:mm')}</Table.Cell>
               </Table.Row>
             ))}


### PR DESCRIPTION
…UserSessionOverheadModal.tsx and AdminAnalyticsUserInteractionsWidget.tsx

:art: Fixed the columns for typeData


[comment]: # "Before continuining with the rest of the Pull Request, make sure the *Title* of this Pull Request contains the following"
[comment]: # "format: [branch] - Short description"
[comment]: # "Where *branch* is the branch you're merging from into master and short description describes the major changes of the PR."
**What this accomplishes**
Closes #247 

**What contributors need to know**
I was originally doing and writing some complex functions that would re-format all the typeData to a better string format. i.e., the typeData for addCourse was Fall2020ics_414 would be reformatted into ics_414 (Fall 2020). There were a bunch of other cases for the other UserInteractionTypes like this that had a similar ugly formatting of typeData (because typeData is an array of strings). However, I decided to instead just have them separated as a comma and keep the integrity of what the typeData actually looks like in the database.
