### PR TITLE
Issue 561 - TestCafe test for adding interests, careers, courses, opportunities to profile

### DIFF
--- a/app/imports/ui/components/shared/explorer/browser-view/ExplorerCard.tsx
+++ b/app/imports/ui/components/shared/explorer/browser-view/ExplorerCard.tsx
@@ -38,7 +38,7 @@ const ExplorerCard: React.FC<ProfileCardProps> = ({ item, type, inProfile }) => 
           renderers={{ link: (localProps) => Router.renderLink(localProps, match) }} />
         { item.interestIDs ? (<InterestList item={item} size="small" />) : ''}
       </Card.Content>
-      <Link to={buildExplorerSlugRoute(match, type, slugName)} className="ui button">
+      <Link to={buildExplorerSlugRoute(match, type, slugName)} className="ui button" id={`see-details-${slugName}-button`}>
         <Icon name="zoom in" />
           &nbsp; {inProfile ? 'See Details / Remove from Profile' : 'See Details / Add to Profile' || 'View More'}
       </Link>

--- a/app/imports/ui/components/shared/explorer/item-view/AddToProfileButton.tsx
+++ b/app/imports/ui/components/shared/explorer/item-view/AddToProfileButton.tsx
@@ -8,6 +8,7 @@ import { ProfileInterests } from '../../../../../api/user/profile-entries/Profil
 import { ProfileOpportunities } from '../../../../../api/user/profile-entries/ProfileOpportunityCollection';
 import { defineMethod, removeItMethod } from '../../../../../api/base/BaseCollection.methods';
 import { PROFILE_ENTRY_TYPE, IProfileEntryTypes } from '../../../../../api/user/profile-entries/ProfileEntryTypes';
+import { COMPONENTIDS } from '../../../../utilities/ComponentIDs';
 import { createDefinitionData, getCollectionName } from './utilities/profile-button';
 
 type ItemType = CareerGoal | Course | Interest | Opportunity;
@@ -93,13 +94,13 @@ const handleRemove = (studentID: string, item: ItemType, type: IProfileEntryType
 const AddToProfileButton: React.FC<AddToProfileButtonProps> = ({ studentID, item, type, added, inverted, floated }) => (
   <React.Fragment>
     {added ? (
-      <Button onClick={handleRemove(studentID, item, type)} size="small" color="teal" floated={floated || 'right'} basic inverted={inverted}>
+      <Button id={COMPONENTIDS.REMOVE_FROM_PROFILE_BUTTON} onClick={handleRemove(studentID, item, type)} size="small" color="teal" floated={floated || 'right'} basic inverted={inverted}>
         <Icon name="user outline" color="grey" inverted={inverted} />
         <Icon name="minus" />
         REMOVE FROM PROFILE
       </Button>
     ) : (
-      <Button size="small" onClick={handleAdd(studentID, item, type)} color="teal" floated={floated || 'right'} basic inverted={inverted}>
+      <Button id={COMPONENTIDS.ADD_TO_PROFILE_BUTTON} size="small" onClick={handleAdd(studentID, item, type)} color="teal" floated={floated || 'right'} basic inverted={inverted}>
         <Icon name="user" color="grey" inverted={inverted} />
         <Icon name="plus" />
         ADD TO PROFILE

--- a/app/imports/ui/utilities/ComponentIDs.ts
+++ b/app/imports/ui/utilities/ComponentIDs.ts
@@ -76,4 +76,7 @@ export enum COMPONENTIDS {
   SIGNIN_FORM_EMAIL = 'signin-form-email',
   SIGNIN_FORM_PASSWORD = 'signin-form-password',
   SIGNIN_FORM_SUBMIT = 'signin-form-submit',
+
+  ADD_TO_PROFILE_BUTTON = 'add-to-profile-button',
+  REMOVE_FROM_PROFILE_BUTTON = 'remove-from-profile-button',
 }

--- a/app/tests/explorer.pages.js
+++ b/app/tests/explorer.pages.js
@@ -1,0 +1,18 @@
+import { Selector } from 'testcafe';
+import { COMPONENTIDS } from '../imports/ui/utilities/ComponentIDs';
+
+class ExplorerPages {
+
+  async testAddAndRemove(testController, slugName) {
+    await testController.click(`#see-details-${slugName}-button`);
+    await testController.click(`#${COMPONENTIDS.ADD_TO_PROFILE_BUTTON}`);
+    const removeButton = Selector(`#${COMPONENTIDS.REMOVE_FROM_PROFILE_BUTTON}`);
+    await testController.expect(removeButton.exists).ok();
+    await testController.click(`#${COMPONENTIDS.REMOVE_FROM_PROFILE_BUTTON}`);
+    const addButton = Selector(`#${COMPONENTIDS.ADD_TO_PROFILE_BUTTON}`);
+    await testController.expect(addButton.exists).ok();
+  }
+
+}
+
+export const explorerPages = new ExplorerPages();

--- a/app/tests/tests.advisor.testcafe.ts
+++ b/app/tests/tests.advisor.testcafe.ts
@@ -1,6 +1,7 @@
 import { landingNavBar } from './navbar.landing.component';
 import { advisorNavBar } from './navbar.advisor.component';
 import { signinPage } from './signin.page';
+import { explorerPages } from './explorer.pages';
 import {
   advisorHomePage,
   advisorFacultyVisibilityPage,
@@ -73,3 +74,15 @@ test('Test advisor top-level pages', async (testController) => {
   await advisorNavBar.gotoManageOpportunitiesPage(testController);
   await manageOpportunitiesPage.isDisplayed(testController);
 });
+
+test('Test adding and removing interests and careers to advisor profile', async (testController) => {
+  await landingNavBar.gotoAdvisorLogin(testController);
+  await signinPage.signin(testController, credentials.advisor);
+
+  await advisorNavBar.gotoInterestsExplorerPage(testController);
+  await explorerPages.testAddAndRemove(testController, 'angular');
+
+  await advisorNavBar.gotoCareerGoalsExplorerPage(testController);
+  await explorerPages.testAddAndRemove(testController, 'game-developer');
+});
+

--- a/app/tests/tests.faculty.testcafe.ts
+++ b/app/tests/tests.faculty.testcafe.ts
@@ -1,6 +1,7 @@
 import { landingNavBar } from './navbar.landing.component';
 import { facultyNavBar } from './navbar.faculty.component';
 import { signinPage } from './signin.page';
+import { explorerPages } from './explorer.pages';
 import {
   facultyHomePage,
   manageOpportunitiesPage,
@@ -69,4 +70,15 @@ test('Test faculty top-level pages', async (testController) => {
   await facultyNavBar.gotoManageReviewPage(testController);
   await manageReviewsPage.isDisplayed(testController);
 
+});
+
+test('Test adding and removing interests and careers to faculty profile', async (testController) => {
+  await landingNavBar.gotoFacultyLogin(testController);
+  await signinPage.signin(testController, credentials.faculty);
+
+  await facultyNavBar.gotoInterestsExplorerPage(testController);
+  await explorerPages.testAddAndRemove(testController, 'angular');
+
+  await facultyNavBar.gotoCareerGoalsExplorerPage(testController);
+  await explorerPages.testAddAndRemove(testController, 'game-developer');
 });

--- a/app/tests/tests.student.testcafe.ts
+++ b/app/tests/tests.student.testcafe.ts
@@ -2,6 +2,7 @@ import { landingNavBar } from './navbar.landing.component';
 import { signinPage } from './signin.page';
 import { studentHomePage } from './student.home.page';
 import { studentNavBar } from './navbar.student.component';
+import { explorerPages } from './explorer.pages';
 import {
   studentDegreePlannerPage,
   studentICEPointsPage,
@@ -73,4 +74,17 @@ test('Test all student top-level pages', async (testController) => {
 
   await studentNavBar.gotoCommunityPage(testController);
   await communityPage.isDisplayed(testController);
+});
+
+test('Test adding and removing interests, careers, courses, and opportunities to profile', async (testController) => {
+  await landingNavBar.gotoStudentLogin(testController);
+  await signinPage.signin(testController, credentials.student.abi);
+  await studentNavBar.gotoInterestsExplorerPage(testController);
+  await explorerPages.testAddAndRemove(testController, 'angular');
+  await studentNavBar.gotoCareerGoalsExplorerPage(testController);
+  await explorerPages.testAddAndRemove(testController, 'game-developer');
+  await studentNavBar.gotoCourseExplorerPage(testController);
+  await explorerPages.testAddAndRemove(testController, 'ics_102');
+  await studentNavBar.gotoOpportunitiesPage(testController);
+  await explorerPages.testAddAndRemove(testController, 'allnet');
 });

--- a/app/tests/tests.student.testcafe.ts
+++ b/app/tests/tests.student.testcafe.ts
@@ -76,15 +76,19 @@ test('Test all student top-level pages', async (testController) => {
   await communityPage.isDisplayed(testController);
 });
 
-test('Test adding and removing interests, careers, courses, and opportunities to profile', async (testController) => {
+test('Test adding and removing interests, careers, courses, and opportunities to student profile', async (testController) => {
   await landingNavBar.gotoStudentLogin(testController);
   await signinPage.signin(testController, credentials.student.abi);
+
   await studentNavBar.gotoInterestsExplorerPage(testController);
   await explorerPages.testAddAndRemove(testController, 'angular');
+
   await studentNavBar.gotoCareerGoalsExplorerPage(testController);
   await explorerPages.testAddAndRemove(testController, 'game-developer');
+
   await studentNavBar.gotoCourseExplorerPage(testController);
   await explorerPages.testAddAndRemove(testController, 'ics_102');
+
   await studentNavBar.gotoOpportunitiesPage(testController);
   await explorerPages.testAddAndRemove(testController, 'allnet');
 });


### PR DESCRIPTION
[comment]: # "Before continuing with the rest of the Pull Request, make sure the *Title* of this Pull Request contains the following"
[comment]: # "format: [branch] - Short description"
[comment]: # "Where *branch* is the branch you're merging from into master and short description describes the major changes of the PR."
**What this accomplishes**
Added a TestCafe test that verifies that the user is able to add interests, careers, courses, and/or opportunities to their profile. This is implemented for students, faculty, and advisors. 

**What contributors need to know**
The adding/removing, as well as the verification is all done in a single function located in radgrad2/app/tests/explorer.pages.js file. I'm not sure if it is better this way, or breaking it down into smaller functions that test adding and removing separately.