### PR TITLE
Issue 634 - Adding a new faculty member gets a Uniforms error for interests and career goals

### DIFF
--- a/app/imports/ui/components/admin/datamodel/user/AddUserForm.tsx
+++ b/app/imports/ui/components/admin/datamodel/user/AddUserForm.tsx
@@ -39,7 +39,7 @@ const AddUserForm: React.FC<AddUserProps> = ({ interests, academicTerms, careerG
   const [role, setRole] = useState<string>('');
   let formRef;
 
-  const handleAdd = (doc) => {
+  const handleAdd = (doc: CombinedProfileDefine) => {
     // console.log('handleAdd(%o)', doc);
     const definitionData: CombinedProfileDefine = doc;
     if (doc.interests) {

--- a/app/imports/ui/components/admin/datamodel/user/AddUserForm.tsx
+++ b/app/imports/ui/components/admin/datamodel/user/AddUserForm.tsx
@@ -197,7 +197,7 @@ const AddUserForm: React.FC<AddUserProps> = ({ interests, academicTerms, careerG
         ) : (
           ''
         )}
-        <SubmitField className="mini basic green" value="Add" />
+        <SubmitField className="mini basic green" value="Add" disabled={false} inputRef={undefined} />
         <ErrorsField />
       </AutoForm>
     </Segment>

--- a/app/imports/ui/components/admin/datamodel/user/AddUserForm.tsx
+++ b/app/imports/ui/components/admin/datamodel/user/AddUserForm.tsx
@@ -39,14 +39,17 @@ const AddUserForm: React.FC<AddUserProps> = ({ interests, academicTerms, careerG
   const [role, setRole] = useState<string>('');
   let formRef;
 
-  const handleAdd = (doc: CombinedProfileDefine) => {
+  const handleAdd = (doc) => {
     // console.log('handleAdd(%o)', doc);
     const definitionData: CombinedProfileDefine = doc;
-    if (doc.interests) {
-      definitionData.interests = doc.interests.map((interest) => interestSlugFromName(interest));
-    } else {
-      definitionData.interests = [];
-    }
+    const docInterests = doc.interests;
+    const slugs = docInterests.map((interest) => interestSlugFromName(interest));
+    definitionData.interests = slugs;
+    // if (doc.interests) {
+    //   definitionData.interests = doc.interests.map((interest) => interestSlugFromName(interest));
+    // } else {
+    //   definitionData.interests = [];
+    // }
     if (doc.careerGoals) {
       definitionData.careerGoals = doc.careerGoals.map((goal) => careerGoalSlugFromName(goal));
     } else {
@@ -79,9 +82,10 @@ const AddUserForm: React.FC<AddUserProps> = ({ interests, academicTerms, careerG
   };
 
   // Hacky way of resetting pictureURL to be empty
-  const handleAddUser = (doc) => {
-    handleAdd(doc);
-  };
+  // const handleAddUser = (doc, fRef) => {
+  //   const model = doc;
+  //   handleAdd(model, fRef);
+  // };
 
   const interestNames = interests.map(docToName);
   const careerGoalNames = careerGoals.map(docToName);
@@ -141,7 +145,7 @@ const AddUserForm: React.FC<AddUserProps> = ({ interests, academicTerms, careerG
     <Segment padded>
       <Header dividing>Add User</Header>
       {/* eslint-disable-next-line no-return-assign */}
-      <AutoForm schema={formSchema} onSubmit={(doc) => handleAddUser(doc)} ref={(ref) => formRef = ref}
+      <AutoForm schema={formSchema} ref={(ref) => formRef = ref} onSubmit={handleAdd}
         showInlineError onChangeModel={handleModelChange}>
         <Form.Group widths="equal">
           <TextField name="username" placeholder="johndoe@foo.edu" />
@@ -197,7 +201,7 @@ const AddUserForm: React.FC<AddUserProps> = ({ interests, academicTerms, careerG
         ) : (
           ''
         )}
-        <SubmitField className="mini basic green" value="Add" disabled={false} inputRef={undefined} />
+        <SubmitField className="mini basic green" value="Add" />
         <ErrorsField />
       </AutoForm>
     </Segment>

--- a/app/imports/ui/components/admin/datamodel/user/AddUserForm.tsx
+++ b/app/imports/ui/components/admin/datamodel/user/AddUserForm.tsx
@@ -42,14 +42,11 @@ const AddUserForm: React.FC<AddUserProps> = ({ interests, academicTerms, careerG
   const handleAdd = (doc) => {
     // console.log('handleAdd(%o)', doc);
     const definitionData: CombinedProfileDefine = doc;
-    const docInterests = doc.interests;
-    const slugs = docInterests.map((interest) => interestSlugFromName(interest));
-    definitionData.interests = slugs;
-    // if (doc.interests) {
-    //   definitionData.interests = doc.interests.map((interest) => interestSlugFromName(interest));
-    // } else {
-    //   definitionData.interests = [];
-    // }
+    if (doc.interests) {
+      definitionData.interests = doc.interests.map((interest) => interestSlugFromName(interest));
+    } else {
+      definitionData.interests = [];
+    }
     if (doc.careerGoals) {
       definitionData.careerGoals = doc.careerGoals.map((goal) => careerGoalSlugFromName(goal));
     } else {
@@ -73,7 +70,6 @@ const AddUserForm: React.FC<AddUserProps> = ({ interests, academicTerms, careerG
       .catch((error) => { RadGradAlert.failure('Add failed', error.message, error);})
       .then(() => {
         RadGradAlert.success('Add succeeded');
-        formRef.reset();
       });
   };
 
@@ -82,10 +78,10 @@ const AddUserForm: React.FC<AddUserProps> = ({ interests, academicTerms, careerG
   };
 
   // Hacky way of resetting pictureURL to be empty
-  // const handleAddUser = (doc, fRef) => {
-  //   const model = doc;
-  //   handleAdd(model, fRef);
-  // };
+  const handleAddUser = (doc, fRef) => {
+    fRef.reset();
+    handleAdd(doc);
+  };
 
   const interestNames = interests.map(docToName);
   const careerGoalNames = careerGoals.map(docToName);
@@ -145,7 +141,7 @@ const AddUserForm: React.FC<AddUserProps> = ({ interests, academicTerms, careerG
     <Segment padded>
       <Header dividing>Add User</Header>
       {/* eslint-disable-next-line no-return-assign */}
-      <AutoForm schema={formSchema} ref={(ref) => formRef = ref} onSubmit={handleAdd}
+      <AutoForm schema={formSchema} ref={(ref) => formRef = ref} onSubmit={doc => handleAddUser(doc, formRef)}
         showInlineError onChangeModel={handleModelChange}>
         <Form.Group widths="equal">
           <TextField name="username" placeholder="johndoe@foo.edu" />


### PR DESCRIPTION
**What this accomplishes**
Small fix to prevent error for interests and career goals when adding a new faculty member.

**What contributors need to know**
Error is caused by app/imports/ui/components/admin/datamodel/user/AddUserForm.tsx at handleAdd function (L42 - L74). Function maps through the interests/opportunities to convert them into slugs and changes definitionData and doc which causes the invalid error since slugs are not allowed values in the schema. Small fix would be to reset the href beforehand to prevent this error. 
