### PR TITLE
Issue 635 - Don't display student participation component when empty

### DIFF
--- a/app/imports/startup/server/startup.ts
+++ b/app/imports/startup/server/startup.ts
@@ -8,6 +8,7 @@ import { removeAllEntities } from '../../api/base/BaseUtilities';
 import { updateFactoids } from '../../api/factoid/Factoids';
 import { PublicStats } from '../../api/public-stats/PublicStatsCollection';
 import { whatsNew } from '../../api/whats-new/WhatsNew';
+import { RadGradForecasts } from '../both/RadGradForecasts';
 import { defineAdminUser, defineTestAdminUser, loadDatabase } from './initialize-db';
 
 /* eslint-disable no-console */
@@ -56,6 +57,8 @@ const normalInitialization = () => {
   userInteractionManager.initialize();
   console.log('  * Initializing cron jobs');
   SyncedCron.start();
+  console.log('  * Initializing forecasts');
+  RadGradForecasts.updateForecasts();
   // Finally, run the daily update to simplify development:
   userInteractionManager.dailyUpdate();
 };

--- a/app/imports/ui/components/shared/explorer/FutureParticipation.tsx
+++ b/app/imports/ui/components/shared/explorer/FutureParticipation.tsx
@@ -12,6 +12,7 @@ interface FutureParticipationProps {
   item: Course | Opportunity;
 }
 
+// Future participation data is updated once a day at midnight
 const FutureParticipation: React.FC<FutureParticipationProps> = ({ item }) => {
   const isCourse = Courses.isDefined(item._id);
   const type = isCourse ? ENROLLMENT_TYPE.COURSE : ENROLLMENT_TYPE.OPPORTUNITY;
@@ -68,12 +69,53 @@ const FutureParticipation: React.FC<FutureParticipationProps> = ({ item }) => {
   }
   if (termsPerYear === 4) {
     return (
+      <div>
+        <p>* Note: Updated once a day at midnight.</p>
+        <Table celled>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>Academic Year</Table.HeaderCell>
+              <Table.HeaderCell>Fall</Table.HeaderCell>
+              <Table.HeaderCell>Winter</Table.HeaderCell>
+              <Table.HeaderCell>Spring</Table.HeaderCell>
+              <Table.HeaderCell>Summer</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>{label1}</Table.Cell>
+              <Table.Cell>{tableData[label1][0]}</Table.Cell>
+              <Table.Cell>{tableData[label1][1]}</Table.Cell>
+              <Table.Cell>{tableData[label1][2]}</Table.Cell>
+              <Table.Cell>{tableData[label1][3]}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>{label2}</Table.Cell>
+              <Table.Cell>{tableData[label2][0]}</Table.Cell>
+              <Table.Cell>{tableData[label2][1]}</Table.Cell>
+              <Table.Cell>{tableData[label2][2]}</Table.Cell>
+              <Table.Cell>{tableData[label2][3]}</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>{label3}</Table.Cell>
+              <Table.Cell>{tableData[label3][0]}</Table.Cell>
+              <Table.Cell>{tableData[label3][1]}</Table.Cell>
+              <Table.Cell>{tableData[label3][2]}</Table.Cell>
+              <Table.Cell>{tableData[label3][3]}</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table>
+      </div>
+    );
+  }
+  return (
+    <div>
+      <p>* Note: Updated once a day at midnight.</p>
       <Table celled>
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell>Academic Year</Table.HeaderCell>
             <Table.HeaderCell>Fall</Table.HeaderCell>
-            <Table.HeaderCell>Winter</Table.HeaderCell>
             <Table.HeaderCell>Spring</Table.HeaderCell>
             <Table.HeaderCell>Summer</Table.HeaderCell>
           </Table.Row>
@@ -84,57 +126,22 @@ const FutureParticipation: React.FC<FutureParticipationProps> = ({ item }) => {
             <Table.Cell>{tableData[label1][0]}</Table.Cell>
             <Table.Cell>{tableData[label1][1]}</Table.Cell>
             <Table.Cell>{tableData[label1][2]}</Table.Cell>
-            <Table.Cell>{tableData[label1][3]}</Table.Cell>
           </Table.Row>
           <Table.Row>
             <Table.Cell>{label2}</Table.Cell>
             <Table.Cell>{tableData[label2][0]}</Table.Cell>
             <Table.Cell>{tableData[label2][1]}</Table.Cell>
             <Table.Cell>{tableData[label2][2]}</Table.Cell>
-            <Table.Cell>{tableData[label2][3]}</Table.Cell>
           </Table.Row>
           <Table.Row>
             <Table.Cell>{label3}</Table.Cell>
             <Table.Cell>{tableData[label3][0]}</Table.Cell>
             <Table.Cell>{tableData[label3][1]}</Table.Cell>
             <Table.Cell>{tableData[label3][2]}</Table.Cell>
-            <Table.Cell>{tableData[label3][3]}</Table.Cell>
           </Table.Row>
         </Table.Body>
       </Table>
-    );
-  }
-  return (
-    <Table celled>
-      <Table.Header>
-        <Table.Row>
-          <Table.HeaderCell>Academic Year</Table.HeaderCell>
-          <Table.HeaderCell>Fall</Table.HeaderCell>
-          <Table.HeaderCell>Spring</Table.HeaderCell>
-          <Table.HeaderCell>Summer</Table.HeaderCell>
-        </Table.Row>
-      </Table.Header>
-      <Table.Body>
-        <Table.Row>
-          <Table.Cell>{label1}</Table.Cell>
-          <Table.Cell>{tableData[label1][0]}</Table.Cell>
-          <Table.Cell>{tableData[label1][1]}</Table.Cell>
-          <Table.Cell>{tableData[label1][2]}</Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <Table.Cell>{label2}</Table.Cell>
-          <Table.Cell>{tableData[label2][0]}</Table.Cell>
-          <Table.Cell>{tableData[label2][1]}</Table.Cell>
-          <Table.Cell>{tableData[label2][2]}</Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <Table.Cell>{label3}</Table.Cell>
-          <Table.Cell>{tableData[label3][0]}</Table.Cell>
-          <Table.Cell>{tableData[label3][1]}</Table.Cell>
-          <Table.Cell>{tableData[label3][2]}</Table.Cell>
-        </Table.Row>
-      </Table.Body>
-    </Table>
+    </div>
   );
 };
 

--- a/app/imports/ui/components/shared/explorer/FutureParticipation.tsx
+++ b/app/imports/ui/components/shared/explorer/FutureParticipation.tsx
@@ -64,7 +64,7 @@ const FutureParticipation: React.FC<FutureParticipationProps> = ({ item }) => {
   }, 0);
 
   if (numParticipants === 0) {
-    return <p>No one has planned to take this course in the next two years yet.</p>;
+    return <p>No one has planned to take this {type} in the next two years yet.</p>;
   }
   if (termsPerYear === 4) {
     return (

--- a/app/imports/ui/components/shared/explorer/FutureParticipation.tsx
+++ b/app/imports/ui/components/shared/explorer/FutureParticipation.tsx
@@ -54,6 +54,18 @@ const FutureParticipation: React.FC<FutureParticipationProps> = ({ item }) => {
       tableData[label1].unshift('N/A');
     }
   }
+
+  const totalArrays = tableData[label1].concat(tableData[label2], tableData[label3]);
+  const numParticipants = totalArrays.reduce((total, participant) => {
+    if (typeof (participant) === 'number') {
+      return total + participant;
+    }
+    return total;
+  }, 0);
+
+  if (numParticipants === 0) {
+    return <p>No one has planned to take this course in the next two years yet.</p>;
+  }
   if (termsPerYear === 4) {
     return (
       <Table celled>

--- a/app/imports/ui/components/shared/explorer/item-view/course/ExplorerCourse.tsx
+++ b/app/imports/ui/components/shared/explorer/item-view/course/ExplorerCourse.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Markdown from 'react-markdown';
 import { useParams } from 'react-router-dom';
-import { Divider, Grid, Header, Segment } from 'semantic-ui-react';
+import { Grid, Segment } from 'semantic-ui-react';
 import { Reviews } from '../../../../../../api/review/ReviewCollection';
 import { ROLE } from '../../../../../../api/role/Role';
 import { Teasers } from '../../../../../../api/teaser/TeaserCollection';
@@ -11,6 +11,7 @@ import { AcademicTerm, Course, Interest, Profile, Review } from '../../../../../
 import StudentExplorerReviewWidget from '../../../../student/explorer/StudentExplorerReviewWidget';
 import EditCourseButton from '../../../manage/course/EditCourseButton';
 import DeleteItemButton from '../../../manage/DeleteItemButton';
+import RadGradHeader from '../../../RadGradHeader';
 import TeaserVideo from '../../../TeaserVideo';
 import FutureParticipation from '../../FutureParticipation';
 import ExplorerReviewWidget from '../ExplorerReviewWidget';
@@ -71,8 +72,7 @@ const ExplorerCourse: React.FC<ExplorerCoursesWidgetProps> = ({ course, courses,
       </Segment>
 
       <Segment textAlign="center">
-        <Header>STUDENTS PARTICIPATING BY SEMESTER</Header>
-        <Divider />
+        <RadGradHeader title='STUDENTS PARTICIPATING BY SEMESTER' />
         <FutureParticipation item={course} />
       </Segment>
 


### PR DESCRIPTION
[comment]: # "Before continuing with the rest of the Pull Request, make sure the *Title* of this Pull Request contains the following"
[comment]: # "format: [branch] - Short description"
[comment]: # "Where *branch* is the branch you're merging from into master and short description describes the major changes of the PR."
**What this accomplishes**
Student participation table is not displayed and a message is shown if there are no future participation students. Also added initializing the forecasts on startup.

**What contributors need to know**
