### PR TITLE
Issue 692: Change the Order on the Visibility Page 

### DIFF
--- a/app/imports/ui/pages/shared/VisibilityPage.tsx
+++ b/app/imports/ui/pages/shared/VisibilityPage.tsx
@@ -119,7 +119,7 @@ const VisibilityPage: React.FC<VisibilityPageProps> = ({ profile }) => {
               <SetWebsiteButton website={data.website} handleChange={handleWebsiteChange} />
             </Form.Group>
             <Form.Checkbox id={COMPONENTIDS.SHARE_INTERESTS} inline name="shareInterests" label="Interests" checked={checkboxState.shareInterests} onChange={handleCheckboxChange} />
-            <Form.Checkbox id={COMPONENTIDS.SHARE_CAREER_GOALS} inline name="shareCareerGoals" label="Career Goals" checked={checkboxState.shareCareerGoals} onChange={handleCheckboxChange} />
+            <Form.Checkbox id={COMPONENTIDS.SHARE_CAREER_GOALS} inline name="shareCareerGoals" label="Careers" checked={checkboxState.shareCareerGoals} onChange={handleCheckboxChange} />
           </Form>
         </Segment>
       </Grid.Column>

--- a/app/imports/ui/pages/student/StudentVisibilityPage.tsx
+++ b/app/imports/ui/pages/student/StudentVisibilityPage.tsx
@@ -121,9 +121,9 @@ const StudentVisibilityPage: React.FC<StudentVisibilityPageProps> = ({ profile }
                 <SetWebsiteButton website={data.website} handleChange={handleWebsiteChange} />
               </Form.Group>
               <Form.Checkbox id={COMPONENTIDS.SHARE_INTERESTS} inline name="shareInterests" label="Interests" checked={checkboxState.shareInterests} onChange={handleCheckboxChange} />
-              <Form.Checkbox id={COMPONENTIDS.SHARE_CAREER_GOALS} inline name="shareCareerGoals" label="Career Goals" checked={checkboxState.shareCareerGoals} onChange={handleCheckboxChange} />
-              <Form.Checkbox id={COMPONENTIDS.SHARE_OPPORTUNITIES} inline name="shareOpportunities" label="Opportunities" checked={checkboxState.shareOpportunities} onChange={handleCheckboxChange} />
+              <Form.Checkbox id={COMPONENTIDS.SHARE_CAREER_GOALS} inline name="shareCareerGoals" label="Careers" checked={checkboxState.shareCareerGoals} onChange={handleCheckboxChange} />
               <Form.Checkbox id={COMPONENTIDS.SHARE_COURSES} inline name="shareCourses" label="Courses" checked={checkboxState.shareCourses} onChange={handleCheckboxChange} />
+              <Form.Checkbox id={COMPONENTIDS.SHARE_OPPORTUNITIES} inline name="shareOpportunities" label="Opportunities" checked={checkboxState.shareOpportunities} onChange={handleCheckboxChange} />
               <Form.Checkbox id={COMPONENTIDS.SHARE_LEVEL} inline name="shareLevel" label="Level" checked={checkboxState.shareLevel} onChange={handleCheckboxChange} />
               <Form.Checkbox id={COMPONENTIDS.SHARE_ICE} inline name="shareICE" label="ICE" checked={checkboxState.shareICE} onChange={handleCheckboxChange} />
             </Form>


### PR DESCRIPTION
Career Goals should now be Careers and the ordering should be consistent with the tabs and checklist.