### PR TITLE
Issue 718 - Fixed eview component on details pages of already completed courses/opportunities showing wrong message

### DIFF
--- a/app/imports/ui/pages/shared/item-view/CourseViewPage.tsx
+++ b/app/imports/ui/pages/shared/item-view/CourseViewPage.tsx
@@ -36,7 +36,7 @@ const isCourseCompleted = (courseSlugName, userID): boolean => {
   let courseCompleted = false;
   const theCourse = Courses.findDocBySlug(courseSlugName);
   const ci = CourseInstances.findNonRetired({
-    userID: userID,
+    studentID: userID,
     courseID: theCourse._id,
   });
   ci.forEach((c) => {

--- a/app/imports/ui/pages/shared/item-view/OpportunityViewPage.tsx
+++ b/app/imports/ui/pages/shared/item-view/OpportunityViewPage.tsx
@@ -47,7 +47,7 @@ interface OpportunityViewPageProps {
 }
 
 const isCompleted = (opportunityID: string, userID: string): boolean => {
-  const ois = OpportunityInstances.findNonRetired({ opportunityID, userID });
+  const ois = OpportunityInstances.findNonRetired({ opportunityID, studentID: userID });
   let completed = false;
   ois.forEach((oi) => {
     if (oi.verified === true) {


### PR DESCRIPTION
[comment]: # "Before continuing with the rest of the Pull Request, make sure the *Title* of this Pull Request contains the following"
[comment]: # "format: [branch] - Short description"
[comment]: # "Where *branch* is the branch you're merging from into master and short description describes the major changes of the PR."
**What this accomplishes**
Review page was displaying a message saying that the user must complete the course or opportunity before leaving a review, even though it was already completed. 

**What contributors need to know**
The issue was that the isCompleted function was using the variable userID when it should studentID
